### PR TITLE
[DFC-75] - Test GA4 tag initialisation in demo app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
         "express": "^4.18.2",
         "govuk-frontend": "^4.7.0",
         "govuk-prototype-kit": "13.13.6",
+        "one-login-ga4": "^0.0.16-dev",
         "path": "^0.12.7"
       },
       "devDependencies": {
         "browser-sync": "^2.29.3",
-        "concurrently": "^8.2.2",
         "eslint": "^8.52.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "gulp": "^4.0.2",
@@ -34,18 +34,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
-      "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
-      "dev": true,
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1534,48 +1522,6 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/concurrently": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.2.tgz",
-      "integrity": "sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "date-fns": "^2.30.0",
-        "lodash": "^4.17.21",
-        "rxjs": "^7.8.1",
-        "shell-quote": "^1.8.1",
-        "spawn-command": "0.0.2",
-        "supports-color": "^8.1.1",
-        "tree-kill": "^1.2.2",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "conc": "dist/bin/concurrently.js",
-        "concurrently": "dist/bin/concurrently.js"
-      },
-      "engines": {
-        "node": "^14.13.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
-      }
-    },
-    "node_modules/concurrently/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/confusing-browser-globals": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
@@ -1719,22 +1665,6 @@
       "dependencies": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
-      }
-    },
-    "node_modules/date-fns": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.21.0"
-      },
-      "engines": {
-        "node": ">=0.11"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/debug": {
@@ -7805,6 +7735,11 @@
         "wrappy": "1"
       }
     },
+    "node_modules/one-login-ga4": {
+      "version": "0.0.16-dev",
+      "resolved": "https://registry.npmjs.org/one-login-ga4/-/one-login-ga4-0.0.16-dev.tgz",
+      "integrity": "sha512-UeNUAj1BIW6avmZhYJwl6QhAv6Fme4KCm+gtiOCERrItzrot5DhoqQ4F02c9V2kO29j2dOMUGa971US05x/gVw=="
+    },
     "node_modules/onetime": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
@@ -8584,12 +8519,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
-      "dev": true
     },
     "node_modules/regex-cache": {
       "version": "0.4.4",
@@ -9592,12 +9521,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/spawn-command": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
-      "integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
-      "dev": true
-    },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -10141,15 +10064,6 @@
       },
       "bin": {
         "nodetouch": "bin/nodetouch.js"
-      }
-    },
-    "node_modules/tree-kill": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-      "dev": true,
-      "bin": {
-        "tree-kill": "cli.js"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -10991,15 +10905,6 @@
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
       "dev": true
-    },
-    "@babel/runtime": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
-      "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
-      "dev": true,
-      "requires": {
-        "regenerator-runtime": "^0.14.0"
-      }
     },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -12138,34 +12043,6 @@
         }
       }
     },
-    "concurrently": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.2.tgz",
-      "integrity": "sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==",
-      "dev": true,
-      "requires": {
-        "chalk": "^4.1.2",
-        "date-fns": "^2.30.0",
-        "lodash": "^4.17.21",
-        "rxjs": "^7.8.1",
-        "shell-quote": "^1.8.1",
-        "spawn-command": "0.0.2",
-        "supports-color": "^8.1.1",
-        "tree-kill": "^1.2.2",
-        "yargs": "^17.7.2"
-      },
-      "dependencies": {
-        "supports-color": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
     "confusing-browser-globals": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
@@ -12282,15 +12159,6 @@
       "requires": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
-      }
-    },
-    "date-fns": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.21.0"
       }
     },
     "debug": {
@@ -17072,6 +16940,11 @@
         "wrappy": "1"
       }
     },
+    "one-login-ga4": {
+      "version": "0.0.16-dev",
+      "resolved": "https://registry.npmjs.org/one-login-ga4/-/one-login-ga4-0.0.16-dev.tgz",
+      "integrity": "sha512-UeNUAj1BIW6avmZhYJwl6QhAv6Fme4KCm+gtiOCERrItzrot5DhoqQ4F02c9V2kO29j2dOMUGa971US05x/gVw=="
+    },
     "onetime": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
@@ -17650,12 +17523,6 @@
       "requires": {
         "resolve": "^1.1.6"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
-      "dev": true
     },
     "regex-cache": {
       "version": "0.4.4",
@@ -18417,12 +18284,6 @@
       "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==",
       "dev": true
     },
-    "spawn-command": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
-      "integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
-      "dev": true
-    },
     "spdx-correct": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -18871,12 +18732,6 @@
       "requires": {
         "nopt": "~1.0.10"
       }
-    },
-    "tree-kill": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-      "dev": true
     },
     "tsconfig-paths": {
       "version": "3.14.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "express": "^4.18.2",
     "govuk-frontend": "^4.7.0",
     "govuk-prototype-kit": "13.13.6",
+    "one-login-ga4": "^0.0.16-dev",
     "path": "^0.12.7"
   },
   "engines": {

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,14 @@
+### Description ###
+
+
+### Tickets ###
+(DFC-**)[https://govukverify.atlassian.net/browse/DFC-**]
+
+### Steps to Reproduce ###
+
+
+### Co-Authored By ###
+
+
+### Additional Information ###
+

--- a/src/app.js
+++ b/src/app.js
@@ -2,7 +2,7 @@ const express = require("express");
 const path = require("path");
 const { configureNunjucks } = require("./config/nunjucks");
 const app = express();
-const port = 3001;
+const port = 3000;
 
 const APP_VIEWS = [
   path.join(__dirname, "views"),

--- a/src/app.js
+++ b/src/app.js
@@ -2,7 +2,7 @@ const express = require("express");
 const path = require("path");
 const { configureNunjucks } = require("./config/nunjucks");
 const app = express();
-const port = 3000;
+const port = 3001;
 
 const APP_VIEWS = [
   path.join(__dirname, "views"),
@@ -11,16 +11,24 @@ const APP_VIEWS = [
 ];
 
 app.set("view engine", configureNunjucks(app, APP_VIEWS));
+
 app.use(
   "/assets",
   express.static(
-    path.join(__dirname, "/node_modules/govuk-frontend/govuk/assets"),
+    path.join(__dirname, "../node_modules/govuk-frontend/govuk/assets"),
   ),
 );
+
+/**GA4 assets */
+app.use(
+  "/ga4-assets",
+  express.static(path.join(__dirname, "../node_modules/one-login-ga4/lib")),
+);
+
 app.use(express.static("public"));
 
 app.get("/", (req, res) => {
-  res.render("index.njk");
+  res.render("index.njk", { ga4ContainerId: "GTM-KD86CMZ" });
 });
 
 app.get("/service-description", (req, res) => {

--- a/src/views/base.njk
+++ b/src/views/base.njk
@@ -27,6 +27,12 @@
       </div>
     </main>
   </div>
+  <script src="/ga4-assets/analytics.js"></script>
+    <script>
+        window.DI.appInit({
+            ga4ContainerId: '{{ ga4ContainerId }}'
+        })
+    </script>
 {% endblock %} 
 
 {% block footer %} 

--- a/src/views/index.njk
+++ b/src/views/index.njk
@@ -3,6 +3,7 @@
 
 <h1 class="govuk-heading-xl">Homepage</h1>
 
+
 {{ govukDetails({ 
   summaryText: "First component accordion", 
   text: "We need to know your nationality so we can work out which elections you're entitled to vote in. If you cannot provide your nationality, you'll have to send copies of identity documents through the post." }) }} 


### PR DESCRIPTION
### Description ###
- Adds the newly published GA4 package to the demo repo
- Extends the express config in `app.js` to include the package and the GTM ID
- Adds the relevant script tags into `base.njk`
- Adds a PR template

### Tickets ###
(DFC-75)[https://govukverify.atlassian.net/browse/DFC-75]

### Steps to Reproduce ###
- `npm install`
- `npm run dev`
- Open `localhost:3000`
- Open the network tab, verify that `analytics.js` and `gtm.js?id...` are successfully returned=