### PR TITLE
DFC|47|GA4|Sandbox|Create form - radio component on test page

### DIFF
--- a/src/views/base.njk
+++ b/src/views/base.njk
@@ -19,6 +19,7 @@
 
 {% block main %}
   <div class="govuk-width-container">
+    {% block beforeContent %}{% endblock %}
     <main id="main-content" class="govuk-main-wrapper">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">

--- a/src/views/organisationType.njk
+++ b/src/views/organisationType.njk
@@ -1,5 +1,58 @@
 {% extends 'base.njk' %}
 {% set title = 'Organisation Type' %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% block beforeContent %}
+
+    {{ govukBackLink({
+  text: "Back",
+  href: "/"
+}) }}
+{% endblock %}
 {% block content %}
-    {# placeholder for content #}
+
+    <form method="get" action="#">
+        {{ govukRadios({
+  name: "organisationType",
+  
+  fieldset: {
+    legend: {
+      text: "Organisation type",
+      isPageHeading: true,
+      classes: "govuk-fieldset__legend--l"
+      
+    }
+  },
+  items: [
+    {
+      value: "government department or Ministry",
+      text: "Government department or Ministry"
+    },
+    {
+      value: "executive Agency",
+      text: "Executive Agency"
+    },
+    {
+      value: "arms length body",
+      text: "Arms length body"
+    },
+    {
+      value: "other",
+      text: "Other"
+    }
+  ],
+  errorMessage: {
+    text: "Select one option"
+  }
+}) }}
+
+        <div class="govuk-button-group">
+            {{ govukButton({
+    text: "Submit"
+  }) }}
+
+        </div>
+    </form>
+
 {% endblock %}


### PR DESCRIPTION
### Description ###

- Adds back link to home page
- Adds radio component , using one from [https://www.sign-in.service.gov.uk/register](url) as reference
- Adds submit button
- Adds error message is user does not select an option
- Adds "get" method to form 

### Tickets ###
(DFC-47)[https://govukverify.atlassian.net/browse/DFC-47]

### Steps to Reproduce ###


### Co-Authored By ###


### Additional Information ###

