### PR TITLE
DFC-127- Bug Fix - Google Tag only loading on Home Page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "express": "^4.18.2",
         "govuk-frontend": "^4.7.0",
         "govuk-prototype-kit": "13.13.6",
-        "one-login-ga4": "^0.0.16-dev",
+        "one-login-ga4": "^0.0.19",
         "path": "^0.12.7"
       },
       "devDependencies": {
@@ -7736,9 +7736,9 @@
       }
     },
     "node_modules/one-login-ga4": {
-      "version": "0.0.16-dev",
-      "resolved": "https://registry.npmjs.org/one-login-ga4/-/one-login-ga4-0.0.16-dev.tgz",
-      "integrity": "sha512-UeNUAj1BIW6avmZhYJwl6QhAv6Fme4KCm+gtiOCERrItzrot5DhoqQ4F02c9V2kO29j2dOMUGa971US05x/gVw=="
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/one-login-ga4/-/one-login-ga4-0.0.19.tgz",
+      "integrity": "sha512-iwQNINeAohvvfMM/Z8RMOWk3kJuD6KQVj0/KyjP/7NaVU0x02mlcRiTgTZCUOvXYLOZSYzi/y7iS1QLFejd0bw=="
     },
     "node_modules/onetime": {
       "version": "5.1.2",
@@ -16941,9 +16941,9 @@
       }
     },
     "one-login-ga4": {
-      "version": "0.0.16-dev",
-      "resolved": "https://registry.npmjs.org/one-login-ga4/-/one-login-ga4-0.0.16-dev.tgz",
-      "integrity": "sha512-UeNUAj1BIW6avmZhYJwl6QhAv6Fme4KCm+gtiOCERrItzrot5DhoqQ4F02c9V2kO29j2dOMUGa971US05x/gVw=="
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/one-login-ga4/-/one-login-ga4-0.0.19.tgz",
+      "integrity": "sha512-iwQNINeAohvvfMM/Z8RMOWk3kJuD6KQVj0/KyjP/7NaVU0x02mlcRiTgTZCUOvXYLOZSYzi/y7iS1QLFejd0bw=="
     },
     "onetime": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "express": "^4.18.2",
     "govuk-frontend": "^4.7.0",
     "govuk-prototype-kit": "13.13.6",
-    "one-login-ga4": "^0.0.16-dev",
+    "one-login-ga4": "^0.0.19",
     "path": "^0.12.7"
   },
   "engines": {

--- a/src/app.js
+++ b/src/app.js
@@ -2,6 +2,7 @@ const express = require("express");
 const path = require("path");
 const { configureNunjucks } = require("./config/nunjucks");
 const validateForm = require("./validateForm");
+const { GA4_CONTAINER_ID } = require("./config/constants");
 const app = express();
 const port = 3000;
 
@@ -30,19 +31,19 @@ app.use(express.static("public"));
 app.use(express.urlencoded({ extended: true }));
 
 app.get("/", (req, res) => {
-  res.render("home.njk", { ga4ContainerId: "GTM-KD86CMZ" });
+  res.render("home.njk", { ga4ContainerId: GA4_CONTAINER_ID });
 });
 
 app.get("/service-description", (req, res) => {
-  res.render("serviceDescription.njk", { ga4ContainerId: "GTM-KD86CMZ" }); // free text
+  res.render("serviceDescription.njk", { ga4ContainerId: GA4_CONTAINER_ID }); // free text
 });
 
 app.get("/organisation-type", (req, res) => {
-  res.render("organisationType.njk", { ga4ContainerId: "GTM-KD86CMZ" }); // radio button
+  res.render("organisationType.njk", { ga4ContainerId: GA4_CONTAINER_ID }); // radio button
 });
 
 app.get("/help-request", (req, res) => {
-  res.render("helpRequest.njk", { ga4ContainerId: "GTM-KD86CMZ" }); // checkbox
+  res.render("helpRequest.njk", { ga4ContainerId: GA4_CONTAINER_ID }); // checkbox
 });
 
 app.listen(port, () => {
@@ -53,7 +54,7 @@ app.post("/validate-organisation-type", (req, res) => {
   const result = validateForm(req.body.organisationType, "/help-request");
   const renderOptions = {
     showError: result.showError,
-    ga4ContainerId: "GTM-KD86CMZ",
+    ga4ContainerId: GA4_CONTAINER_ID,
   };
   if (result.showError) {
     res.render("organisationType.njk", renderOptions);
@@ -66,7 +67,7 @@ app.post("/validate-help-request", (req, res) => {
   const result = validateForm(req.body.helpWithHint, "/service-description");
   const renderOptions = {
     showError: result.showError,
-    ga4ContainerId: "GTM-KD86CMZ",
+    ga4ContainerId: GA4_CONTAINER_ID,
   };
   if (result.showError) {
     res.render("helpRequest.njk", renderOptions);

--- a/src/app.js
+++ b/src/app.js
@@ -34,15 +34,15 @@ app.get("/", (req, res) => {
 });
 
 app.get("/service-description", (req, res) => {
-  res.render("serviceDescription.njk"); // free text
+  res.render("serviceDescription.njk", { ga4ContainerId: "GTM-KD86CMZ" }); // free text
 });
 
 app.get("/organisation-type", (req, res) => {
-  res.render("organisationType.njk", { showError: false }); // radio button
+  res.render("organisationType.njk", { ga4ContainerId: "GTM-KD86CMZ" }); // radio button
 });
 
 app.get("/help-request", (req, res) => {
-  res.render("helpRequest.njk", { showError: false }); // checkbox
+  res.render("helpRequest.njk", { ga4ContainerId: "GTM-KD86CMZ" }); // checkbox
 });
 
 app.listen(port, () => {
@@ -51,8 +51,12 @@ app.listen(port, () => {
 
 app.post("/validate-organisation-type", (req, res) => {
   const result = validateForm(req.body.organisationType, "/help-request");
+  const renderOptions = {
+    showError: result.showError,
+    ga4ContainerId: "GTM-KD86CMZ",
+  };
   if (result.showError) {
-    res.render("organisationType.njk", { showError: true });
+    res.render("organisationType.njk", renderOptions);
   } else if (result.redirect) {
     res.redirect(result.redirect);
   }
@@ -60,8 +64,12 @@ app.post("/validate-organisation-type", (req, res) => {
 
 app.post("/validate-help-request", (req, res) => {
   const result = validateForm(req.body.helpWithHint, "/service-description");
+  const renderOptions = {
+    showError: result.showError,
+    ga4ContainerId: "GTM-KD86CMZ",
+  };
   if (result.showError) {
-    res.render("helpRequest.njk", { showError: true });
+    res.render("helpRequest.njk", renderOptions);
   } else if (result.redirect) {
     res.redirect(result.redirect);
   }

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -1,0 +1,3 @@
+const GA4_CONTAINER_ID = "GTM-KD86CMZ";
+
+module.exports = { GA4_CONTAINER_ID };

--- a/src/views/common/base.njk
+++ b/src/views/common/base.njk
@@ -44,6 +44,16 @@
       .appInit({ga4ContainerId: '{{ ga4ContainerId }}'});
     window
       .DI
+      .analyticsGa4
+      .pageViewTracker
+      .trackOnPageLoad({
+        statusCode: 200, englishPageTitle: `english version of the title`, // Replace with the actual page title
+        taxonomy_level1: 'tes tax 1', // Replace with the actual taxonomy level 1
+        taxonomy_level2: 'tes tax 2' // Replace with the actual taxonomy level 2
+      });
+
+    window
+      .DI
       .cookieBannerInit("localhost");
   </script>
 {% endblock %}


### PR DESCRIPTION
### Description ###
Ensure the Google Tag Manager (GTM) script is loaded on all pages by adding the GTM container ID to other page rendering methods and implementing proper error handling.

1.  Upgrade node package to latest version
2. Modified the rendering methods for form pages (/service-description, /organisation-type, /help-request) to include the GTM container ID in the rendering options.
3. Included the GTM container ID in the rendering options for error pages.
4. Testing: Verified the changes locally to confirm that the GTM script loads on all relevant pages including error endpoints.

<img width="1512" alt="Screenshot 2023-11-16 at 14 18 36" src="https://github.com/govuk-one-login/di-fec-ga4-demo/assets/148252375/3988376a-adaf-467a-a34a-afc58564cbe2">

### Tickets ###
(DFC-127)[https://govukverify.atlassian.net/browse/DFC-127]

### Steps to Reproduce ###

Check the GTM scripts loads on all relevant pages including error endpoints 

### Co-Authored By ###


### Additional Information ###

