### PR TITLE
DFC-46 | GA4 | Sandbox | Create form - free text component on test page

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -38,11 +38,11 @@ app.get("/service-description", (req, res) => {
 });
 
 app.get("/organisation-type", (req, res) => {
-  res.render("organisationType.njk", { showError: false }); // radio button
+  res.render("organisationType.njk"); // radio button
 });
 
 app.get("/help-request", (req, res) => {
-  res.render("helpRequest.njk", { showError: false }); // checkbox
+  res.render("helpRequest.njk"); // checkbox
 });
 
 app.listen(port, () => {
@@ -62,6 +62,15 @@ app.post("/validate-help-request", (req, res) => {
   const result = validateForm(req.body.helpWithHint, "/service-description");
   if (result.showError) {
     res.render("helpRequest.njk", { showError: true });
+  } else if (result.redirect) {
+    res.redirect(result.redirect);
+  }
+});
+
+app.post("/validate-service-description", (req, res) => {
+  const result = validateForm(req.body.serviceDescription, "#");
+  if (result.showError) {
+    res.render("serviceDescription.njk", { showError: true });
   } else if (result.redirect) {
     res.redirect(result.redirect);
   }

--- a/src/app.js
+++ b/src/app.js
@@ -68,7 +68,7 @@ app.post("/validate-help-request", (req, res) => {
 });
 
 app.post("/validate-service-description", (req, res) => {
-  const result = validateForm(req.body.serviceDescription, "#");
+  const result = validateForm(req.body.serviceDescription, "/");
   if (result.showError) {
     res.render("serviceDescription.njk", { showError: true });
   } else if (result.redirect) {

--- a/src/views/serviceDescription.njk
+++ b/src/views/serviceDescription.njk
@@ -4,13 +4,13 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% block backLink %}
-    {{ govukBackLink({ text: "Back", href: "/help-request" }) }}
+  {{ govukBackLink({ text: "Back", href: "/help-request" }) }}
 {% endblock %}
 {% block content %}
 
-    <form method="post" action="/validate-service-description" id="serviceDescriptionForm">
+  <form method="post" action="/validate-service-description" id="serviceDescriptionForm">
 
-        {{ govukTextarea({
+    {{ govukTextarea({
   name: "serviceDescription",
   id: "service-description",
   label: {
@@ -23,11 +23,11 @@
   },
   errorMessage: {
     text: "Enter a short description of your service"
-  }
+  } if showError
 }) }}
-        {{ govukButton({
+    {{ govukButton({
   text: "Continue",
   type: "submit"
 }) }}
-    </form>
+  </form>
 {% endblock %}

--- a/src/views/serviceDescription.njk
+++ b/src/views/serviceDescription.njk
@@ -1,5 +1,33 @@
 {% extends 'common/base.njk' %}
 {% set title = 'Service Description' %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% block backLink %}
+    {{ govukBackLink({ text: "Back", href: "/help-request" }) }}
+{% endblock %}
 {% block content %}
-    {# placeholder for content #}
+
+    <form method="post" action="/validate-service-description" id="serviceDescriptionForm">
+
+        {{ govukTextarea({
+  name: "serviceDescription",
+  id: "service-description",
+  label: {
+    text: "Service Description",
+    classes: "govuk-label--l",
+    isPageHeading: true
+  },
+  hint: {
+    text: "Describe your service, what it does, who it helps and why? Also tell us if it's a new service that has not launched yet."
+  },
+  errorMessage: {
+    text: "Enter a short description of your service"
+  }
+}) }}
+        {{ govukButton({
+  text: "Continue",
+  type: "submit"
+}) }}
+    </form>
 {% endblock %}


### PR DESCRIPTION
### Description ###

- Introduces a textarea component.
- Implements error handling for the textarea form.
- Redirects to the home page when the user enters text and clicks continue since the select form page is not yet created.

### Tickets ###
(DFC-46)[https://govukverify.atlassian.net/browse/DFC-46]

### Steps to Reproduce ###

1. Navigate to /service-description page
2. Test the error handling of the form.
3. Verify the redirection functionality to the home page when text is entered.

### Co-Authored By ###


### Additional Information ###

Not sure if we wanted to limit characters entered in textarea ?
Saving data from form entry will be added later/ another ticket 