### PR TITLE
Dfc 124 dfc ga4 save form data response to local storage

### DIFF
--- a/public/javascript/cookie.js
+++ b/public/javascript/cookie.js
@@ -8,7 +8,9 @@ window.DI = window.DI || {};
   var cookies = {
     hasConsentForAnalytics: function () {
       var COOKIES_PREFERENCES_SET = "cookies_preferences_set";
-      var cookieConsent = JSON.parse(decodeURIComponent(this.getCookie(COOKIES_PREFERENCES_SET)));
+      var cookieConsent = JSON.parse(
+        decodeURIComponent(this.getCookie(COOKIES_PREFERENCES_SET)),
+      );
       return cookieConsent ? cookieConsent.analytics === true : false;
     },
 
@@ -34,12 +36,17 @@ window.DI = window.DI || {};
         options = {};
       }
 
-      var cookieString = name + "=" + encodeURIComponent(JSON.stringify(values));
+      var cookieString =
+        name + "=" + encodeURIComponent(JSON.stringify(values));
       if (options.days) {
         var date = new Date();
         date.setTime(date.getTime() + options.days * 24 * 60 * 60 * 1000);
         cookieString =
-          cookieString + "; Expires=" + date.toUTCString() + "; Path=/; Domain=" + domain;
+          cookieString +
+          "; Expires=" +
+          date.toUTCString() +
+          "; Path=/; Domain=" +
+          domain;
       }
 
       if (document.location.protocol === "https:") {

--- a/public/javascript/cookieBanner.js
+++ b/public/javascript/cookieBanner.js
@@ -26,7 +26,7 @@ window.DI = window.DI || {};
       function (event) {
         event.preventDefault();
         setBannerCookieConsent(true, domain);
-      }.bind(this)
+      }.bind(this),
     );
 
     rejectCookies.addEventListener(
@@ -34,7 +34,7 @@ window.DI = window.DI || {};
       function (event) {
         event.preventDefault();
         setBannerCookieConsent(false, domain);
-      }.bind(this)
+      }.bind(this),
     );
 
     var hideButtons = Array.prototype.slice.call(hideCookieBanner);
@@ -44,7 +44,7 @@ window.DI = window.DI || {};
         function (event) {
           event.preventDefault();
           hideElement(cookieBannerContainer);
-        }.bind(this)
+        }.bind(this),
       );
     });
 
@@ -60,7 +60,7 @@ window.DI = window.DI || {};
       COOKIES_PREFERENCES_SET,
       { analytics: analyticsConsent },
       { days: 365 },
-      domain
+      domain,
     );
 
     hideElement(cookieBanner);

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,14 +1,11 @@
-### Description ###
+### Description
 
+### Tickets
 
-### Tickets ###
 (DFC-**)[https://govukverify.atlassian.net/browse/DFC-**]
 
-### Steps to Reproduce ###
+### Steps to Reproduce
 
+### Co-Authored By
 
-### Co-Authored By ###
-
-
-### Additional Information ###
-
+### Additional Information

--- a/src/app.js
+++ b/src/app.js
@@ -14,18 +14,10 @@ const APP_VIEWS = [
 
 app.set("view engine", configureNunjucks(app, APP_VIEWS));
 
-app.use(
-  "/assets",
-  express.static(
-    path.join(__dirname, "../node_modules/govuk-frontend/govuk/assets"),
-  ),
-);
+app.use("/assets", express.static(path.join(__dirname, "../node_modules/govuk-frontend/govuk/assets")));
 
 /**GA4 assets */
-app.use(
-  "/ga4-assets",
-  express.static(path.join(__dirname, "../node_modules/one-login-ga4/lib")),
-);
+app.use("/ga4-assets", express.static(path.join(__dirname, "../node_modules/one-login-ga4/lib")));
 
 app.use(express.static("public"));
 app.use(express.urlencoded({ extended: true }));
@@ -51,7 +43,7 @@ app.get("/choose-location", (req, res) => {
 });
 
 app.get("/confirmation-page", (req, res) => {
-  res.render("confirmationPage.njk"); // select
+  res.render("confirmationPage.njk");
 });
 
 app.listen(port, () => {
@@ -97,7 +89,7 @@ app.post("/validate-service-description", (req, res) => {
 });
 
 app.post("/validate-choose-location", (req, res) => {
-  const result = validateForm(req.body.chooseLocation, "/");
+  const result = validateForm(req.body.chooseLocation, "/confirmation-page");
   const renderOptions = {
     showError: result.showError,
     ga4ContainerId: GA4_CONTAINER_ID,

--- a/src/app.js
+++ b/src/app.js
@@ -14,18 +14,10 @@ const APP_VIEWS = [
 
 app.set("view engine", configureNunjucks(app, APP_VIEWS));
 
-app.use(
-  "/assets",
-  express.static(
-    path.join(__dirname, "../node_modules/govuk-frontend/govuk/assets")
-  )
-);
+app.use("/assets", express.static(path.join(__dirname, "../node_modules/govuk-frontend/govuk/assets")));
 
 /**GA4 assets */
-app.use(
-  "/ga4-assets",
-  express.static(path.join(__dirname, "../node_modules/one-login-ga4/lib"))
-);
+app.use("/ga4-assets", express.static(path.join(__dirname, "../node_modules/one-login-ga4/lib")));
 
 app.use(express.static("public"));
 app.use(express.urlencoded({ extended: true }));
@@ -42,18 +34,24 @@ app.get("/organisation-type", (req, res) => {
   res.render("organisationType.njk", { ga4ContainerId: GA4_CONTAINER_ID }); // radio button
 });
 
-app.get("/help-request", (req, res) => {
-  res.render("helpRequest.njk", { ga4ContainerId: GA4_CONTAINER_ID }); // checkbox
+app.get("/help-with-hint", (req, res) => {
+  res.render("helpWithHint.njk", { ga4ContainerId: GA4_CONTAINER_ID }); // checkbox
 });
+
 app.get("/choose-location", (req, res) => {
   res.render("chooseLocation.njk", { ga4ContainerId: GA4_CONTAINER_ID }); // select
 });
+
+app.get("/confirmation-page", (req, res) => {
+  res.render("confirmationPage.njk"); // select
+});
+
 app.listen(port, () => {
   console.log(`Example app listening on port ${port}`);
 });
 
 app.post("/validate-organisation-type", (req, res) => {
-  const result = validateForm(req.body.organisationType, "/help-request");
+  const result = validateForm(req.body.organisationType, "/help-with-hint");
   const renderOptions = {
     showError: result.showError,
     ga4ContainerId: GA4_CONTAINER_ID,
@@ -65,14 +63,14 @@ app.post("/validate-organisation-type", (req, res) => {
   }
 });
 
-app.post("/validate-help-request", (req, res) => {
+app.post("/validate-help-with-hint", (req, res) => {
   const result = validateForm(req.body.helpWithHint, "/service-description");
   const renderOptions = {
     showError: result.showError,
     ga4ContainerId: GA4_CONTAINER_ID,
   };
   if (result.showError) {
-    res.render("helpRequest.njk", renderOptions);
+    res.render("helpWithHint.njk", renderOptions);
   } else if (result.redirect) {
     res.redirect(result.redirect);
   }

--- a/src/app.js
+++ b/src/app.js
@@ -14,10 +14,18 @@ const APP_VIEWS = [
 
 app.set("view engine", configureNunjucks(app, APP_VIEWS));
 
-app.use("/assets", express.static(path.join(__dirname, "../node_modules/govuk-frontend/govuk/assets")));
+app.use(
+  "/assets",
+  express.static(
+    path.join(__dirname, "../node_modules/govuk-frontend/govuk/assets"),
+  ),
+);
 
 /**GA4 assets */
-app.use("/ga4-assets", express.static(path.join(__dirname, "../node_modules/one-login-ga4/lib")));
+app.use(
+  "/ga4-assets",
+  express.static(path.join(__dirname, "../node_modules/one-login-ga4/lib")),
+);
 
 app.use(express.static("public"));
 app.use(express.urlencoded({ extended: true }));

--- a/src/views/chooseLocation.njk
+++ b/src/views/chooseLocation.njk
@@ -10,11 +10,16 @@
 
   <form method="post" action="/validate-choose-location" id="chooseLocationForm">
 
+    <h1 class="govuk-heading-l">Choose your location</h1>
+
     {{ govukSelect({
   id: "choose-location",
   name: "chooseLocation",
-  label: {
-    text: "Choose location"
+  fieldset: {
+    legend: {
+      text: "Choose your location",
+      classes: "govuk-fieldset__legend--l"
+    }
   },
   hint: {
     text: "This can be different to where you went before"
@@ -71,4 +76,30 @@
   type: "submit"
 }) }}
   </form>
+
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      const storedChooseLocation = localStorage.getItem("chooseLocation");
+      const dropdownToSelect = document.getElementById("choose-location");
+
+      // if check must remain, else default text does not show
+      if (storedChooseLocation) {
+        dropdownToSelect.value = storedChooseLocation;
+      }
+    });
+
+    document
+      .getElementById("chooseLocationForm")
+      .addEventListener("submit", function (event) {
+        event.preventDefault();
+
+        const chooseLocation = document
+          .getElementById("choose-location")
+          .value;
+
+        localStorage.setItem("chooseLocation", chooseLocation);
+
+        this.submit();
+      });
+  </script>
 {% endblock %}

--- a/src/views/confirmationPage.njk
+++ b/src/views/confirmationPage.njk
@@ -1,0 +1,10 @@
+{% extends 'common/base.njk' %}
+{% set title = 'Confirmation Page' %}
+
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% block backLink %}
+  {{ govukBackLink({ text: "Back", href: "/choose-location" }) }}
+{% endblock %}
+
+<p>placeholder</p>
+{% block content %}{% endblock %}

--- a/src/views/helpWithHint.njk
+++ b/src/views/helpWithHint.njk
@@ -1,5 +1,5 @@
 {% extends 'common/base.njk' %}
-{% set title = 'Help with hINT' %}
+{% set title = 'Help with hint' %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}

--- a/src/views/helpWithHint.njk
+++ b/src/views/helpWithHint.njk
@@ -59,33 +59,33 @@
   <script>
     document.addEventListener("DOMContentLoaded", function () {
       const storedHelpWithHints = localStorage.getItem("helpWithHint");
+      const form = document.getElementById("helpWithHintForm");
+
       if (storedHelpWithHints) {
         const storedValues = storedHelpWithHints.split("/");
-        const form = document.getElementById("helpWithHintForm");
-
-        form
-          .elements
-          .helpWithHint
-          .forEach((checkbox) => {
-            if (storedValues.includes(checkbox.value)) {
-              checkbox.checked = true;
-            }
-          })
+        storedValues.forEach((value) => {
+          const checkbox = form.querySelector(`input[value="${value}"]`);
+          if (checkbox) {
+            checkbox.checked = true;
+          }
+        });
       }
 
-      const form = document.getElementById("helpWithHintForm");
       form.addEventListener("submit", function (event) {
         event.preventDefault();
 
-        const helpWithHint = document
+        const helpWithHint = form
           .querySelector('input[name="helpWithHint"]:checked')
           .value;
 
-        const checkedItems = Array.from(document.querySelectorAll('input[type=checkbox]:checked'), (checkbox) => checkbox.value);
+        const checkedItems = Array
+          .from(form.querySelectorAll('input[type=checkbox]:checked'))
+          .map((checkbox) => checkbox.value);
 
         localStorage.setItem("helpWithHint", checkedItems.join("/"));
-      });
 
+        form.submit();
+      });
     });
   </script>
 {% endblock %}

--- a/src/views/helpWithHint.njk
+++ b/src/views/helpWithHint.njk
@@ -1,5 +1,5 @@
 {% extends 'common/base.njk' %}
-{% set title = 'Help Request' %}
+{% set title = 'Help with hINT' %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
@@ -9,7 +9,7 @@
 {% endblock %}
 {% block content %}
 
-  <form method="post" action="/validate-help-request" id="helpRequestForm" >
+  <form method="post" action="/validate-help-with-hint" id="helpWithHintForm" >
 
     {{ govukCheckboxes({
   name: "helpWithHint",
@@ -55,4 +55,33 @@
   type: "submit"
 }) }}
   </form>
+
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      const storedHelpWithHint = localStorage.getItem("helpWithHint");
+      const form = document.forms.helpWithHintForm;
+
+      const checkboxToCheck = Array
+        .from(form.elements.helpWithHint)
+        .find((checkbox) => checkbox.value === storedHelpWithHint);
+
+      if (checkboxToCheck) {
+        checkboxToCheck.checked = true;
+      }
+    });
+
+    document
+      .getElementById("helpWithHintForm")
+      .addEventListener("submit", function (event) {
+        event.preventDefault();
+
+        var helpWithHint = document
+          .querySelector('input[name="helpWithHint"]:checked')
+          .value;
+
+        localStorage.setItem("helpWithHint", helpWithHint);
+
+        this.submit();
+      });
+  </script>
 {% endblock %}

--- a/src/views/helpWithHint.njk
+++ b/src/views/helpWithHint.njk
@@ -58,30 +58,34 @@
 
   <script>
     document.addEventListener("DOMContentLoaded", function () {
-      const storedHelpWithHint = localStorage.getItem("helpWithHint");
-      const form = document.forms.helpWithHintForm;
+      const storedHelpWithHints = localStorage.getItem("helpWithHint");
+      if (storedHelpWithHints) {
+        const storedValues = storedHelpWithHints.split("/");
+        const form = document.getElementById("helpWithHintForm");
 
-      const checkboxToCheck = Array
-        .from(form.elements.helpWithHint)
-        .find((checkbox) => checkbox.value === storedHelpWithHint);
-
-      if (checkboxToCheck) {
-        checkboxToCheck.checked = true;
+        form
+          .elements
+          .helpWithHint
+          .forEach((checkbox) => {
+            if (storedValues.includes(checkbox.value)) {
+              checkbox.checked = true;
+            }
+          })
       }
-    });
 
-    document
-      .getElementById("helpWithHintForm")
-      .addEventListener("submit", function (event) {
+      const form = document.getElementById("helpWithHintForm");
+      form.addEventListener("submit", function (event) {
         event.preventDefault();
 
-        var helpWithHint = document
+        const helpWithHint = document
           .querySelector('input[name="helpWithHint"]:checked')
           .value;
 
-        localStorage.setItem("helpWithHint", helpWithHint);
+        const checkedItems = Array.from(document.querySelectorAll('input[type=checkbox]:checked'), (checkbox) => checkbox.value);
 
-        this.submit();
+        localStorage.setItem("helpWithHint", checkedItems.join("/"));
       });
+
+    });
   </script>
 {% endblock %}

--- a/src/views/home.njk
+++ b/src/views/home.njk
@@ -56,4 +56,8 @@ service." }) }}
     <div>
         <a href="#" class="govuk-link govuk-link--no-visited-state govuk-body"> View a printable version of the whole guide</a>
     </div>
+
+    <script>
+        localStorage.clear();
+    </script>
 {% endblock %}

--- a/src/views/organisationType.njk
+++ b/src/views/organisationType.njk
@@ -14,6 +14,7 @@
   <form method="post" action="/validate-organisation-type" id="organisationForm">
     {{ govukRadios({
   name: "organisationType",
+  id: "organisation-type",
   fieldset: {
     legend: {
       text: "Organisation type",
@@ -46,9 +47,36 @@
     {{ govukButton({
     text: "Continue",
     type: 'submit'
-   
   }) }}
 
   </form>
 
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      const storedOrganisationType = localStorage.getItem("organisationType");
+
+      const form = document.forms.organisationForm
+
+      if (storedOrganisationType) {
+        Array
+          .from(form.elements.organisationType)
+          .find((radio) => radio.value === storedOrganisationType)
+          .checked = true
+      }
+    });
+
+    document
+      .getElementById("organisationForm")
+      .addEventListener("submit", function (event) {
+        event.preventDefault();
+
+        const organisationType = document
+          .querySelector('input[name="organisationType"]:checked')
+          .value;
+
+        localStorage.setItem("organisationType", organisationType);
+
+        this.submit();
+      });
+  </script>
 {% endblock %}

--- a/src/views/serviceDescription.njk
+++ b/src/views/serviceDescription.njk
@@ -4,7 +4,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% block backLink %}
-  {{ govukBackLink({ text: "Back", href: "/help-request" }) }}
+  {{ govukBackLink({ text: "Back", href: "/help-with-hint" }) }}
 {% endblock %}
 {% block content %}
 
@@ -30,4 +30,26 @@
   type: "submit"
 }) }}
   </form>
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      const storedServiceDescription = localStorage.getItem("serviceDescription");
+      const textField = document.getElementById("service-description");
+
+      textField.value = storedServiceDescription ?? null;
+    });
+
+    document
+      .getElementById("serviceDescriptionForm")
+      .addEventListener("submit", function (event) {
+        event.preventDefault();
+
+        const serviceDescription = document
+          .getElementById("service-description")
+          .value;
+
+        localStorage.setItem("serviceDescription", serviceDescription);
+
+        this.submit();
+      });
+  </script>
 {% endblock %}


### PR DESCRIPTION
### Tickets ###
(DFC-124)[https://govukverify.atlassian.net/browse/DFC-124]

### Steps to Reproduce ###
Homepage > organisationType > help request 
dev tools > application > you can see the values are stored
Click back you'll see the values are selected

- Additional preselection added

FYI i tried and decided to go against a reusable "preselect and save to store" function, as this created more code than if the functionality remained on the form pages, therefore less performant. It was also more buggy because of the script included on the base.njk file, it was intermittent due to the `DOMContentLoaded` required (i've left the commit incase this is of interest). 
