### PR TITLE
DFC-135-Connect the Navigation across the form pages

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -46,7 +46,7 @@ app.get("/help-request", (req, res) => {
   res.render("helpRequest.njk", { ga4ContainerId: GA4_CONTAINER_ID }); // checkbox
 });
 app.get("/choose-location", (req, res) => {
-  res.render("chooseLocation.njk"); // select
+  res.render("chooseLocation.njk", { ga4ContainerId: GA4_CONTAINER_ID }); // select
 });
 app.listen(port, () => {
   console.log(`Example app listening on port ${port}`);
@@ -78,7 +78,7 @@ app.post("/validate-help-request", (req, res) => {
   }
 });
 app.post("/validate-service-description", (req, res) => {
-  const result = validateForm(req.body.serviceDescription, "/");
+  const result = validateForm(req.body.serviceDescription, "/choose-location");
   const renderOptions = {
     showError: result.showError,
     ga4ContainerId: GA4_CONTAINER_ID,
@@ -92,8 +92,12 @@ app.post("/validate-service-description", (req, res) => {
 
 app.post("/validate-choose-location", (req, res) => {
   const result = validateForm(req.body.chooseLocation, "/");
+  const renderOptions = {
+    showError: result.showError,
+    ga4ContainerId: GA4_CONTAINER_ID,
+  };
   if (result.showError) {
-    res.render("chooseLocation.njk", { showError: true });
+    res.render("chooseLocation.njk", renderOptions);
   } else if (result.redirect) {
     res.redirect(result.redirect);
   }


### PR DESCRIPTION
- Altered the redirection path for service-description, redirecting users to the Choose Location page upon data submission instead of the home page.
- Added the GA4ContainerId to the rendering methods for the Choose Location page, so that google tag is loaded both initially and during error handling.

### Description ###


### Tickets ###
(DFC-**)[https://govukverify.atlassian.net/browse/DFC-**]

### Steps to Reproduce ###
check the user journey is -->
Home → Organisation Type → HelpRequest → Service Description → Choose Location --> ( back to Home as ManageForm page has not been created yet)


### Co-Authored By ###


### Additional Information ###

