### PR TITLE
BUG|DFC-147 |Entering through root, results in redirection to the Journey Guard

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -27,18 +27,18 @@ app.set("view engine", configureNunjucks(app, APP_VIEWS));
 app.use(
   "/assets",
   express.static(
-    path.join(__dirname, "../node_modules/govuk-frontend/govuk/assets"),
-  ),
+    path.join(__dirname, "../node_modules/govuk-frontend/govuk/assets")
+  )
 );
 
 /**GA4 assets */
 app.use(
   "/ga4-assets",
-  express.static(path.join(__dirname, "../node_modules/one-login-ga4/lib")),
+  express.static(path.join(__dirname, "../node_modules/one-login-ga4/lib"))
 );
 app.use(
   session({
-    secret: sessionId, // Should I make this more secure?
+    secret: sessionId,
     resave: false,
     saveUninitialized: true,
     cookie: { secure: false },

--- a/src/config/middleware.js
+++ b/src/config/middleware.js
@@ -15,9 +15,13 @@ const checkSessionAndRedirect = (req, res, next) => {
     };
   }
 
-  // If the user doesn't have a session and is not on the homepage, redirect to Journey Guard Page
+  // If the user doesn't have a session and is not on the homepage, redirect to Journey Guard Page but if entering on / take them to welcome page
   if (!hasSession && !isOnHomepage) {
     return res.render("journeyGuard.njk");
+  }
+  // If the user has a session and the path is / redirect to Home Page path which is "/welcome"
+  if (hasSession && req.path === "/") {
+    return res.redirect("/welcome");
   }
 
   next();


### PR DESCRIPTION
### Description
Journey Guard Logic:

If the user enters a non-homepage path without a session ID, they are redirected to the Journey Guard. The Journey Guard provides a link to the home page.

If the user is on the homepage without a session ID, one is set, allowing them to navigate freely.

Initially, a bug existed because the app defaulted to "/"  first before entering the form page, setting the session ID prematurely. I resolved this by changing the home page path to "/welcome." But this meant that , entering localhost:3000 or "/" would redirect users to the Journey Guard page. 

Now, I have tried to add some logic in my checkSessionAndRedirect middleware function so that if user is entering via / to redirect them to /welcome but this is now causing the logic of my middleware function to fail and encounter the same type of problem I had initially. I am not sure what else I can do because bug is caused by the default behaviour of the node app rather than the code ?

### Tickets

(DFC-147)[https://govukverify.atlassian.net/browse/DFC-147]

### Steps to Reproduce

1. Run app
2. Enter url for form page
3. See console.logs to see the behaviour I described
### Co-Authored By

### Additional Information
