### PR TITLE
DRAFT|Bug|Dfc 147| entering through root results in redirection to the journey guard- v2

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -12,7 +12,7 @@ const {
   setPageTitle,
   setContentId,
 } = require("./config/gtmMiddleware");
-const { journeyGuard } = require("./config/middleware");
+const { checkSessionAndRedirect } = require("./config/middleware");
 const app = express();
 const port = 3000;
 
@@ -52,26 +52,9 @@ app.use(setStatusCode);
 app.use(setTaxonomyValues);
 app.use(setPageTitle);
 app.use(setContentId);
-app.use(
-  [
-    "/enter-email",
-    "/service-description",
-    "/organisation-type",
-    "/help-with-hint",
-    "/choose-location",
-    "/confirmation-page",
-  ],
-  journeyGuard
-);
-app.get("/", (req, res) => {
-  console.log("entering through / redirecting to /welcome");
-  res.redirect("/welcome");
-});
+app.use(checkSessionAndRedirect);
+
 app.get("/welcome", (req, res) => {
-  console.log("setting session ID");
-  req.session.userSession = {
-    startedJourney: true,
-  };
   res.render("home.njk");
 });
 

--- a/src/app.js
+++ b/src/app.js
@@ -27,18 +27,18 @@ app.set("view engine", configureNunjucks(app, APP_VIEWS));
 app.use(
   "/assets",
   express.static(
-    path.join(__dirname, "../node_modules/govuk-frontend/govuk/assets"),
-  ),
+    path.join(__dirname, "../node_modules/govuk-frontend/govuk/assets")
+  )
 );
 
 /**GA4 assets */
 app.use(
   "/ga4-assets",
-  express.static(path.join(__dirname, "../node_modules/one-login-ga4/lib")),
+  express.static(path.join(__dirname, "../node_modules/one-login-ga4/lib"))
 );
 app.use(
   session({
-    secret: sessionId, // Should I make this more secure?
+    secret: sessionId,
     resave: false,
     saveUninitialized: true,
     cookie: { secure: false },

--- a/src/app.js
+++ b/src/app.js
@@ -12,7 +12,7 @@ const {
   setPageTitle,
   setContentId,
 } = require("./config/gtmMiddleware");
-const { checkSessionAndRedirect } = require("./config/middleware");
+const { journeyGuard } = require("./config/middleware");
 const app = express();
 const port = 3000;
 
@@ -52,9 +52,26 @@ app.use(setStatusCode);
 app.use(setTaxonomyValues);
 app.use(setPageTitle);
 app.use(setContentId);
-app.use(checkSessionAndRedirect);
-
+app.use(
+  [
+    "/enter-email",
+    "/service-description",
+    "/organisation-type",
+    "/help-with-hint",
+    "/choose-location",
+    "/confirmation-page",
+  ],
+  journeyGuard
+);
+app.get("/", (req, res) => {
+  console.log("entering through / redirecting to /welcome");
+  res.redirect("/welcome");
+});
 app.get("/welcome", (req, res) => {
+  console.log("setting session ID");
+  req.session.userSession = {
+    startedJourney: true,
+  };
   res.render("home.njk");
 });
 

--- a/src/config/gtmMiddleware.js
+++ b/src/config/gtmMiddleware.js
@@ -25,7 +25,7 @@ const setTaxonomyValues = (req, res, next) => {
     res.locals.taxonomyLevel1 = pathFound.taxonomyLevel1 || "undefined";
     res.locals.taxonomyLevel2 = pathFound.taxonomyLevel2 || "undefined";
   } else {
-    console.log("Path not found");
+    // console.log("Path not found");
     res.locals.taxonomyLevel1 = "undefined";
     res.locals.taxonomyLevel2 = "undefined";
   }
@@ -43,7 +43,7 @@ const setPageTitle = (req, res, next) => {
   if (pathFound) {
     res.locals.englishPageTitle = pathFound.pageTitle || "undefined";
   } else {
-    console.log("Path not found");
+    // console.log("Path not found");
     res.locals.englishPageTitle = "undefined";
   }
 
@@ -61,7 +61,7 @@ const setContentId = (req, res, next) => {
     console.log(pathFound.path);
     res.locals.contentId = pathFound.contentId || "undefined";
   } else {
-    console.log("Path not found");
+    // console.log("Path not found");
     res.locals.englishPageTitle = "undefined";
   }
 

--- a/src/config/gtmMiddleware.js
+++ b/src/config/gtmMiddleware.js
@@ -18,7 +18,9 @@ const setStatusCode = (req, res, next) => {
 // Middleware to instantiate the values for taxonomy levels 1 and 2 for the On Page Load tracker
 const setTaxonomyValues = (req, res, next) => {
   const url = req.url;
-  const pathFound = ROUTE_INFO.find((route) => route.path === url.split("?")[0]);
+  const pathFound = ROUTE_INFO.find(
+    (route) => route.path === url.split("?")[0]
+  );
   if (pathFound) {
     res.locals.taxonomyLevel1 = pathFound.taxonomyLevel1 || "undefined";
     res.locals.taxonomyLevel2 = pathFound.taxonomyLevel2 || "undefined";
@@ -34,7 +36,9 @@ const setTaxonomyValues = (req, res, next) => {
 // Middleware to instantiate the value for the pageTitle for the On Page Load tracker
 const setPageTitle = (req, res, next) => {
   const url = req.url;
-  const pathFound = ROUTE_INFO.find((route) => route.path === url.split("?")[0]);
+  const pathFound = ROUTE_INFO.find(
+    (route) => route.path === url.split("?")[0]
+  );
 
   if (pathFound) {
     res.locals.englishPageTitle = pathFound.pageTitle || "undefined";
@@ -49,9 +53,12 @@ const setPageTitle = (req, res, next) => {
 // Middleware to instantiate the value for the pageTitle for the On Page Load tracker
 const setContentId = (req, res, next) => {
   const url = req.url;
-  const pathFound = ROUTE_INFO.find((route) => route.path === url.split("?")[0]);
+  const pathFound = ROUTE_INFO.find(
+    (route) => route.path === url.split("?")[0]
+  );
 
   if (pathFound) {
+    console.log(pathFound.path);
     res.locals.contentId = pathFound.contentId || "undefined";
   } else {
     console.log("Path not found");

--- a/src/config/middleware.js
+++ b/src/config/middleware.js
@@ -1,4 +1,4 @@
-const journeyGuard = (req, res, next) => {
+const checkSessionAndRedirect = (req, res, next) => {
   // Check if the user has an active session
   const hasSession =
     req.session &&
@@ -9,20 +9,44 @@ const journeyGuard = (req, res, next) => {
   const isOnHomepage = req.path === "/welcome";
 
   // If the user is on the Home Page and does not have a session, set it
-  // if (isOnHomepage && !hasSession) {
-  //   console.log(
-  //     `user has no session but is on the HP , so lets set the session id`
-  //   );
-  // }
+  if (isOnHomepage && !hasSession) {
+    console.log(
+      `user has no session but is on the HP , so lets set the session id`
+    );
+    req.session.userSession = {
+      startedJourney: true,
+    };
+  }
 
   // If the user doesn't have a session and is not on the homepage, redirect to Journey Guard Page but if entering on / take them to welcome page
   if (!hasSession && !isOnHomepage) {
+    if (req.path === "/") {
+      console.log(
+        `user is not on HP and does not have a session, the path is ${req.path} so lets redirect to welcome`
+      );
+      return res.redirect("./welcome");
+    } else {
+      console.log(
+        `user is not on HP and does not have a session, the path is ${req.path}`
+      );
+      return res.render("journeyGuard.njk");
+    }
+  }
+  // If the user has a session and the path is / redirect to Home Page path which is "/welcome"
+  if (hasSession && req.path === "/") {
     console.log(
-      `user is not on HP and does not have a session, the path is ${req.path}`
+      `user has session but the path is ${req.path}, let redirect to /welcome`
     );
-    return res.render("journeyGuard.njk");
+    return res.redirect("/welcome");
+  }
+
+  if (!hasSession && req.path === "/") {
+    console.log(
+      `user has no session but the path is ${req.path}, let redirect to /welcome`
+    );
+    return res.redirect("/welcome");
   }
 
   next();
 };
-module.exports = { journeyGuard };
+module.exports = { checkSessionAndRedirect };

--- a/src/config/middleware.js
+++ b/src/config/middleware.js
@@ -1,4 +1,4 @@
-const checkSessionAndRedirect = (req, res, next) => {
+const journeyGuard = (req, res, next) => {
   // Check if the user has an active session
   const hasSession =
     req.session &&
@@ -9,44 +9,20 @@ const checkSessionAndRedirect = (req, res, next) => {
   const isOnHomepage = req.path === "/welcome";
 
   // If the user is on the Home Page and does not have a session, set it
-  if (isOnHomepage && !hasSession) {
-    console.log(
-      `user has no session but is on the HP , so lets set the session id`
-    );
-    req.session.userSession = {
-      startedJourney: true,
-    };
-  }
+  // if (isOnHomepage && !hasSession) {
+  //   console.log(
+  //     `user has no session but is on the HP , so lets set the session id`
+  //   );
+  // }
 
   // If the user doesn't have a session and is not on the homepage, redirect to Journey Guard Page but if entering on / take them to welcome page
   if (!hasSession && !isOnHomepage) {
-    if (req.path === "/") {
-      console.log(
-        `user is not on HP and does not have a session, the path is ${req.path} so lets redirect to welcome`
-      );
-      return res.redirect("./welcome");
-    } else {
-      console.log(
-        `user is not on HP and does not have a session, the path is ${req.path}`
-      );
-      return res.render("journeyGuard.njk");
-    }
-  }
-  // If the user has a session and the path is / redirect to Home Page path which is "/welcome"
-  if (hasSession && req.path === "/") {
     console.log(
-      `user has session but the path is ${req.path}, let redirect to /welcome`
+      `user is not on HP and does not have a session, the path is ${req.path}`
     );
-    return res.redirect("/welcome");
-  }
-
-  if (!hasSession && req.path === "/") {
-    console.log(
-      `user has no session but the path is ${req.path}, let redirect to /welcome`
-    );
-    return res.redirect("/welcome");
+    return res.render("journeyGuard.njk");
   }
 
   next();
 };
-module.exports = { checkSessionAndRedirect };
+module.exports = { journeyGuard };

--- a/src/config/middleware.js
+++ b/src/config/middleware.js
@@ -10,6 +10,9 @@ const checkSessionAndRedirect = (req, res, next) => {
 
   // If the user is on the Home Page and does not have a session, set it
   if (isOnHomepage && !hasSession) {
+    console.log(
+      `user has no session but is on the HP , so lets set the session id`
+    );
     req.session.userSession = {
       startedJourney: true,
     };
@@ -17,10 +20,30 @@ const checkSessionAndRedirect = (req, res, next) => {
 
   // If the user doesn't have a session and is not on the homepage, redirect to Journey Guard Page but if entering on / take them to welcome page
   if (!hasSession && !isOnHomepage) {
-    return res.render("journeyGuard.njk");
+    if (req.path === "/") {
+      console.log(
+        `user is not on HP and does not have a session, the path is ${req.path} so lets redirect to welcome`
+      );
+      return res.redirect("./welcome");
+    } else {
+      console.log(
+        `user is not on HP and does not have a session, the path is ${req.path}`
+      );
+      return res.render("journeyGuard.njk");
+    }
   }
   // If the user has a session and the path is / redirect to Home Page path which is "/welcome"
   if (hasSession && req.path === "/") {
+    console.log(
+      `user has session but the path is ${req.path}, let redirect to /welcome`
+    );
+    return res.redirect("/welcome");
+  }
+
+  if (!hasSession && req.path === "/") {
+    console.log(
+      `user has no session but the path is ${req.path}, let redirect to /welcome`
+    );
     return res.redirect("/welcome");
   }
 

--- a/src/config/middleware.js
+++ b/src/config/middleware.js
@@ -15,9 +15,13 @@ const checkSessionAndRedirect = (req, res, next) => {
     };
   }
 
-  // If the user doesn't have a session and is not on the homepage, redirect to Journey Guard Page
+  // If the user doesn't have a session and is not on the homepage, redirect to Journey Guard Page but if entering on / take them to welcome page
   if (!hasSession && !isOnHomepage) {
     return res.render("journeyGuard.njk");
+  }
+  // If the user has a session and the path is / redirect to Home Page path which is "/welcome"
+  if (hasSession && req.path === "/") {
+    return res.redirect("/welcome");
   }
 
   next();


### PR DESCRIPTION
### Description
Journey Guard Logic:

If the user enters a non-homepage path without a session ID, they are redirected to the Journey Guard. The Journey Guard provides a link to the home page.

If the user is on the homepage without a session ID, one is set, allowing them to navigate freely.

Initially, a bug existed because the app defaulted to "/" first before entering the form page, setting the session ID prematurely. I resolved this by changing the home page path to "/welcome." But this meant that , entering localhost:3000 or "/" would redirect users to the Journey Guard page.

Now, I have tried to add some logic in my checkSessionAndRedirect middleware function so that if user is entering via / to redirect them to /welcome but this is now causing the logic of my middleware function to fail and encounter the same type of problem I had initially. I am not sure what else I can do because bug is caused by the default behaviour of the node app rather than the code ?

### Tickets

(DFC-147)[https://govukverify.atlassian.net/browse/DFC-147]

### Steps to Reproduce

1. Run app
2. Enter url for form page
3. See console.logs to see the behaviour I described

### Co-Authored By

### Additional Information
