### PR TITLE
DFC | GA4 | Sandbox | Add multiple languages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
         "express": "^4.18.2",
         "govuk-frontend": "^4.7.0",
         "govuk-prototype-kit": "13.13.6",
+        "i18next": "^23.7.7",
+        "i18next-fs-backend": "^2.3.0",
+        "i18next-http-middleware": "^3.5.0",
         "one-login-ga4": "^0.0.21",
         "path": "^0.12.7"
       },
@@ -34,6 +37,17 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.5.tgz",
+      "integrity": "sha512-NdUTHcPe4C99WxPub+K9l9tK5/lV4UXIoaHSYgzco9BCyjKAAwzdBI+wWtYqHt7LJdbo74ZjRPJgzVweq1sz0w==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -5589,6 +5603,38 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/i18next": {
+      "version": "23.7.7",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.7.7.tgz",
+      "integrity": "sha512-peTvdT+Lma+o0LfLFD7IC2M37N9DJ04dH0IJYOyOHRhDfLo6nK36v7LkrQH35C2l8NHiiXZqGirhKESlEb/5PA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
+    "node_modules/i18next-fs-backend": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-2.3.0.tgz",
+      "integrity": "sha512-N0SS2WojoVIh2x/QkajSps8RPKzXqryZsQh12VoFY4cLZgkD+62EPY2fY+ZjkNADu8xA5I5EadQQXa8TXBKN3w=="
+    },
+    "node_modules/i18next-http-middleware": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/i18next-http-middleware/-/i18next-http-middleware-3.5.0.tgz",
+      "integrity": "sha512-BqATaFCMVHJYZX4cBmhvpBqZNvnvjjmcSzxJvLWTwgJ4gn5kwYoyVikn7AB5kxiQrFjSuZsjDFv76CdsAHwpZw=="
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -8520,6 +8566,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
+    },
     "node_modules/regex-cache": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
@@ -10905,6 +10956,14 @@
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
       "dev": true
+    },
+    "@babel/runtime": {
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.5.tgz",
+      "integrity": "sha512-NdUTHcPe4C99WxPub+K9l9tK5/lV4UXIoaHSYgzco9BCyjKAAwzdBI+wWtYqHt7LJdbo74ZjRPJgzVweq1sz0w==",
+      "requires": {
+        "regenerator-runtime": "^0.14.0"
+      }
     },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -15319,6 +15378,24 @@
       "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
       "dev": true
     },
+    "i18next": {
+      "version": "23.7.7",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.7.7.tgz",
+      "integrity": "sha512-peTvdT+Lma+o0LfLFD7IC2M37N9DJ04dH0IJYOyOHRhDfLo6nK36v7LkrQH35C2l8NHiiXZqGirhKESlEb/5PA==",
+      "requires": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
+    "i18next-fs-backend": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-2.3.0.tgz",
+      "integrity": "sha512-N0SS2WojoVIh2x/QkajSps8RPKzXqryZsQh12VoFY4cLZgkD+62EPY2fY+ZjkNADu8xA5I5EadQQXa8TXBKN3w=="
+    },
+    "i18next-http-middleware": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/i18next-http-middleware/-/i18next-http-middleware-3.5.0.tgz",
+      "integrity": "sha512-BqATaFCMVHJYZX4cBmhvpBqZNvnvjjmcSzxJvLWTwgJ4gn5kwYoyVikn7AB5kxiQrFjSuZsjDFv76CdsAHwpZw=="
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -17523,6 +17600,11 @@
       "requires": {
         "resolve": "^1.1.6"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "regex-cache": {
       "version": "0.4.4",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "express": "^4.18.2",
     "govuk-frontend": "^4.7.0",
     "govuk-prototype-kit": "13.13.6",
+    "i18next": "^23.7.7",
+    "i18next-fs-backend": "^2.3.0",
+    "i18next-http-middleware": "^3.5.0",
     "one-login-ga4": "^0.0.21",
     "path": "^0.12.7"
   },

--- a/src/config/i18next.js
+++ b/src/config/i18next.js
@@ -1,0 +1,24 @@
+module.exports = {
+  i18nextConfigurationOptions: function (path) {
+    return {
+      debug: false, // Whether to enable debug mode for i18next
+      fallbackLng: "en", // The default language to fall back to if a translation is not available in the requested language
+      preload: ["en", "cy"], // An array of languages to preload, typically the default and supported languages
+      supportedLngs: ["en", "cy"], // An array of supported languages
+      backend: {
+        loadPath: path, // The path pattern to load translations from, e.g., locales/{{lng}}/{{ns}}.json
+        allowMultiLoading: true, // Whether to allow loading multiple namespaces at once
+      },
+      detection: {
+        lookupCookie: "lng", // The name of the cookie to look for language information
+        lookupQuerystring: "lng", // The query string parameter to look for language information
+        order: ["querystring", "cookie"], // The order in which to look for language information (query string first, then cookie)
+        caches: ["cookie"], // Caching mechanism for language detection
+        ignoreCase: true, // Whether to ignore case when detecting language
+        cookieSecure: true, // Whether to set the secure flag for the cookie
+        cookieDomain: "", // The domain for the cookie (empty for the current domain)
+        cookieSameSite: "", // The SameSite attribute for the cookie
+      },
+    };
+  },
+};

--- a/src/config/nunjucks.js
+++ b/src/config/nunjucks.js
@@ -1,4 +1,5 @@
 const nunjucks = require("nunjucks");
+const i18next = require("i18next");
 
 module.exports = {
   configureNunjucks: (app, viewsPath) => {
@@ -6,6 +7,10 @@ module.exports = {
       autoescape: true,
       express: app,
       noCache: true,
+    });
+    nunjucksEnv.addFilter("translate", function (key, options) {
+      const translate = i18next.getFixedT(this.ctx.i18n.language);
+      return translate(key, options);
     });
 
     return nunjucksEnv;

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1,0 +1,167 @@
+{
+  "general": {
+    "buttons": {
+      "startNow": "Dechrau Nawr",
+      "continue": "Parhau"
+    },
+    "govuk": {
+      "backLink": "Yn ôl",
+      "skipLink": "Neidio i'r prif gynnwys",
+      "phaseBanner": {
+        "tag": "Alffa",
+        "content": "Mae hwn yn wasanaeth newydd - bydd eich <a class=\"govuk-link\" rel=\"noopener\" target=\"_blank\" href=\"https://signin.dev.account.gov.uk/contact-us\">adborth</a> yn ein helpu i'w wella. Am fwy o wybodaeth, os gwelwch yn dda <a href=\"/\">ailgychwynwch</a> eich taith"
+      }
+    },
+    "cookie": {
+      "cookieBanner": {
+        "title": "Cwcis ar GA4",
+        "heading": "Cwcis ar GA4",
+        "paragraph1": "Rydym yn defnyddio rhai cwcis hanfodol i wneud i'r gwasanaeth hwn weithio.",
+        "paragraph2": "Hoffem osod cwcis ychwanegol er mwyn gallu cofio eich gosodiadau, deall sut mae pobl yn defnyddio'r gwasanaeth a gwneud gwelliannau.",
+        "changeCookiePreferencesLink": "newid eich gosodiadau cwcis",
+        "cookieBannerAccept": {
+          "paragraph1": "Rydych wedi derbyn cwcis ychwanegol. Gallwch",
+          "paragraph2": "ar unrhyw adeg."
+        }
+      },
+      "cookieBannerReject": {
+        "paragraph1": "Rydych wedi gwrthod cwcis ychwanegol. Gallwch",
+        "paragraph2": "ar unrhyw adeg."
+      },
+      "buttonAcceptText": "Derbyn cwcis dadansoddi",
+      "buttonRejectText": "Gwrthod cwcis dadansoddi",
+      "linkViewCookies": "Gweld cwcis",
+      "cookieBannerHideLinkText": "Cuddio'r neges gwcis"
+    },
+    "footer": {
+      "help": {
+        "linkText": "Cymorth"
+      },
+      "cookies": {
+        "linkText": "Cwcis"
+      },
+      "contact": {
+        "linkText": "Cysylltu"
+      },
+      "terms": {
+        "linkText": "Telerau ac Amodau"
+      }
+    }
+  },
+
+  "pages": {
+    "journeyGuard": {
+      "title": "Gofal Taith",
+      "content": {
+        "header": "Yn anffodus, ni allwch gyrchu OneLogin GOV.UK o'r dudalen hon",
+        "paragraph1": " <a href=\"/welcome\" class=\"govuk-link\"> Ewch i dudalen flaenoriaeth OneLogin GOV.UK</a> i ddod o hyd i'r gwasanaeth sydd ei angen arnoch."
+      }
+    },
+    "home": {
+      "title": "Hafan",
+      "content": {
+        "header": "Defnyddio eich Mewngofnod One Login GOV.UK",
+        "navHeading": "Cynnwys",
+        "list1": "Mewngofnodi i'ch Mewngofnod One Login GOV.UK",
+        "list2": "Dolen Inbound Profi",
+        "list3": "Dolen Allgofnodi Profi",
+        "subheading1": "Mewngofnodi i'ch Mewngofnod One Login GOV.UK",
+        "paragraph1": "Gallwch ddefnyddio eich Mewngofnod One Login GOV.UK i gyrchu rhai gwasanaethau'r llywodraeth.",
+        "paragraph2": "Nid yw'n gweithio gyda phob <a href=\"#\" class=\"govuk-link\"> cyfrifon a gwasanaethau llywodraeth</a> eto (er enghraifft, Porth Llywodraethol neu Gredyd Cynhwysol)",
+        "paragraph3": "Yn y dyfodol, byddwch yn gallu defnyddio eich Mewngofnod One Login GOV.UK i gyrchu'r holl wasanaethau ar GOV.UK.",
+        "paragraph4": "Gweler y <a href=\"#\" class=\"govuk-link\"> gwasanaethau y gallwch eu defnyddio gyda Mewngofnod One Login GOV.UK.</a>",
+        "insetText": "Os oes angen Mewngofnod One Login GOV.UK arnoch i ddefnyddio gwasanaeth, ac nad oes gennych un eisoes, byddwch yn gallu creu un pan fyddwch yn defnyddio'r gwasanaeth hwnnw am y tro cyntaf.",
+        "paragraph5": "Mewngofnodi i:",
+        "list4": "newid eich manylion mewngofnodi (cyfeiriad e-bost, cyfrinair neu sut rydych yn cael codau diogelwch)",
+        "list5": "gweld a chael mynediad at y gwasanaethau rydych wedi'u defnyddio gyda'ch Mewngofnod One Login GOV.UK",
+        "list6": "dileu eich Mewngofnod One Login GOV.UK",
+        "subheading2": "Adrodd problem neu roi adborth",
+        "paragraph6": "I adrodd problem gyda'ch Mewngofnod One Login GOV.UK neu roi adborth, <a href=\"https://home.account.gov.uk/contact-gov-uk-one-login\" class=\"govuk-link\">cysylltwch â thîm Mewngofnod One Login GOV.UK</a>.",
+        "pagination": {
+          "text": "Gwasanaethau y gallwch eu defnyddio gyda Mewngofnod One Login GOV.UK"
+        },
+        "printGuideLinkText": "Gweld fersiwn argraffu cyflawn y canllaw"
+      }
+    },
+    "organisationType": {
+      "title": "Math o Fudiad",
+      "content": {
+        "header": "Beth yw math o fudiad yr ydych chi?",
+        "options": {
+          "governmentDepartmentOrMinistry": "Adran neu Weinidogiaeth Llywodraethol",
+          "executiveAgency": "Asiantaeth Weithredol",
+          "armsLengthBody": "Corff ar Gael yn Annibynnol",
+          "other": "Arall"
+        },
+        "errors": {
+          "validationError": "Dewiswch un opsiwn"
+        }
+      }
+    },
+    "helpWithHint": {
+      "title": "Cymorth Gyda Chyffyrdd",
+      "content": {
+        "header": "Beth hoffech chi gael cymorth gyda?",
+        "hint": "Ticiwch bob un sy'n berthnasol - bydd hyn yn ein helpu i ddeall eich anghenion cychwynnol",
+        "options": {
+          "accessIntegrationEnvironment": "Cael mynediad at yr amgylchedd integreiddio i brofi Mewngofnod One Login GOV.UK",
+          "technicalDiscussion": "Cael trafodaeth dechnegol",
+          "onboardingProcess": "Cerdded trwy'r broses ymuno",
+          "moreDetail": "Deall rhagor am raglen Mewngofnod One Login GOV.UK",
+          "other": "Arall"
+        },
+        "errors": {
+          "validationError": "Dewiswch un neu fwy o opsiynau"
+        }
+      }
+    },
+    "serviceDescription": {
+      "title": "Disgrifiad Gwasanaeth",
+      "content": {
+        "header": "Disgrifiwch eich gwasanaeth",
+        "hint": "Disgrifiwch eich gwasanaeth, yr hyn y mae'n ei wneud, pwy mae'n helpu ac am beth? Dywedwch hefyd os yw'n wasanaeth newydd nad yw wedi'i lansio eto.",
+        "errors": {
+          "validationError": "Rhowch grynodeb byr o'ch gwasanaeth"
+        }
+      }
+    },
+    "chooseLocation": {
+      "title": "Dewiswch eich Lleoliad",
+      "content": {
+        "header": "Dewiswch eich lleoliad",
+        "hint": "Gall hyn fod yn wahanol i ble aethoch o'r blaen",
+        "options": {
+          "chooseLocation": "Dewiswch leoliad",
+          "eastMidlands": "Canolbarth Dwyrain",
+          "eastEngland": "Dwyrain Lloegr",
+          "london": "Llundain",
+          "northEast": "Gogledd Ddwyrain",
+          "northWest": "Gogledd Orllewin",
+          "southEast": "De Ddwyrain",
+          "southWest": "De Orllewin",
+          "westMidlands": "Canolbarth Orllewin",
+          "yorkshireAndHumber": "Efrog a Humber"
+        },
+        "errors": {
+          "validationError": "Dewiswch leoliad"
+        }
+      }
+    },
+    "enterEmail": {
+      "title": "Rhowch eich Cyfeiriad E-bost",
+      "content": {
+        "header": "Rhowch eich cyfeiriad e-bost",
+        "errors": {
+          "validationError": "Rhowch eich cyfeiriad e-bost"
+        }
+      }
+    },
+    "summaryPage": {
+      "title": "Tudalen Crynodeb",
+      "content": {
+        "header": "Gwirio atebion",
+        "changeLink": "Newid"
+      }
+    }
+  }
+}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1,0 +1,167 @@
+{
+  "general": {
+    "buttons": {
+      "startNow": "Start Now",
+      "continue": "Continue"
+    },
+    "govuk": {
+      "backLink": "Back",
+      "skipLink": "Skip to main content",
+      "phaseBanner": {
+        "tag": "Alpha",
+        "content": "This is a new service - your <a class=\"govuk-link\" rel=\"noopener\" target=\"_blank\" href=\"https://signin.dev.account.gov.uk/contact-us\">feedback</a>  will help us to improve it. For more information, please <a href=\"/\">restart</a> your journey"
+      }
+    },
+    "cookie": {
+      "cookieBanner": {
+        "title": "Cookies on GA4",
+        "heading": "Cookies on GA4",
+        "paragraph1": "We use some essential cookies to make this service work.",
+        "paragraph2": "We'd like to set additional cookies so we can remember your settings, understand how people use the service and make improvements.",
+        "changeCookiePreferencesLink": "change your cookie settings",
+        "cookieBannerAccept": {
+          "paragraph1": "You've accepted additional cookies. You can",
+          "paragraph2": "at any time."
+        }
+      },
+      "cookieBannerReject": {
+        "paragraph1": "You've rejected additional cookies. You can ",
+        "paragraph2": " at any time."
+      },
+      "buttonAcceptText": "Accept analytics cookies",
+      "buttonRejectText": "Reject analytics cookies",
+      "linkViewCookies": "View cookies",
+      "cookieBannerHideLinkText": "Hide cookie message"
+    },
+    "footer": {
+      "help": {
+        "linkText": "Help"
+      },
+      "cookies": {
+        "linkText": "Cookies"
+      },
+      "contact": {
+        "linkText": "Contact"
+      },
+      "terms": {
+        "linkText": "Terms and conditions"
+      }
+    }
+  },
+
+  "pages": {
+    "journeyGuard": {
+      "title": "Journey Guard",
+      "content": {
+        "header": "Sorry, you can not access OneLogin GOV.UK from this page",
+        "paragraph1": " <a href=\"/welcome\" class=\"govuk-link\"> Go to the GOV.UK OneLogin homepage</a> to find the service you need."
+      }
+    },
+    "home": {
+      "title": "Home",
+      "content": {
+        "header": "Using your GOV.UK One Login",
+        "navHeading": "Contents",
+        "list1": "Sign in to your GOV.UK One Login",
+        "list2": "Test Inbound Link",
+        "list3": "Test Outbound link",
+        "subheading1": "Sign in to your GOV.UK One Login",
+        "paragraph1": "You can use your GOV.UK One Login to access some government services.",
+        "paragraph2": "It does not work with all <a href=\"#\" class=\"govuk-link\">government accounts and services</a> yet (for example Government Gateway or Universal Credit)",
+        "paragraph3": "In the future, you'll be able to use your GOV.UK One Login to access all services on GOV.UK.",
+        "paragraph4": "See the <a href=\"#\" class=\"govuk-link\"> services you can use with GOV.UK One Login.</a>",
+        "insetText": "If you need a GOV.UK One Login to use a service, and you do not already have one, you'll be able to create one when you first use that service.",
+        "paragraph5": "Sign in to:",
+        "list4": "change your sign in details (email address, password or how you get security codes)",
+        "list5": "see and access the services you've used with your GOV.UK One Login",
+        "list6": "delete your GOV.UK One Login",
+        "subheading2": "Report a problem or give feedback",
+        "paragraph6": "To report a problem with your GOV.UK One Login or give feedback,<a href=\"https://home.account.gov.uk/contact-gov-uk-one-login\" class=\"govuk-link\">contact the GOV.UK One Login team</a >.",
+        "pagination": {
+          "text": "Services you can use with GOV.UK One Login"
+        },
+        "printGuideLinkText": "View a printable version of the whole guide"
+      }
+    },
+    "organisationType": {
+      "title": "Organisation Type",
+      "content": {
+        "header": "What is your organisation type?",
+        "options": {
+          "governmentDepartmentOrMinistry": "Government department or Ministry",
+          "executiveAgency": "Executive Agency",
+          "armsLengthBody": "Arms length body",
+          "other": "Other"
+        },
+        "errors": {
+          "validationError": "Select one option"
+        }
+      }
+    },
+    "helpWithHint": {
+      "title": "Help With Hint",
+      "content": {
+        "header": "What would you like help with?",
+        "hint": "Tick all that apply - this will help us understand your initial needs",
+        "options": {
+          "accessIntegrationEnvironment": "Getting access to the integration environment to test GOV.UK One Login",
+          "technicalDiscussion": "Having a technical discussion",
+          "onboardingProcess": "Walking through the onboarding process",
+          "moreDetail": "Understanding the GOV.UK One Login programme in more detail",
+          "other": "Other"
+        },
+        "errors": {
+          "validationError": "Select one or more options"
+        }
+      }
+    },
+    "serviceDescription": {
+      "title": "Service Description",
+      "content": {
+        "header": "Describe your service",
+        "hint": "Describe your service, what it does, who it helps and why? Also tell us if it's a new service that has not launched yet.",
+        "errors": {
+          "validationError": "Enter a short description of your service"
+        }
+      }
+    },
+    "chooseLocation": {
+      "title": "chooseLocation",
+      "content": {
+        "header": "Choose your location",
+        "hint": "This can be different to where you went before",
+        "options": {
+          "chooseLocation": "Choose location",
+          "eastMidlands": "East Midlands",
+          "eastEngland": "East of England",
+          "london": "London",
+          "northEast": "North East",
+          "northWest": "North West",
+          "southEast": "South East",
+          "southWest": "South West",
+          "westMidlands": "West Midlands",
+          "yorkshireAndHumber": "Yorkshire and the Humber"
+        },
+        "errors": {
+          "validationError": "Select a location"
+        }
+      }
+    },
+    "enterEmail": {
+      "title": "Enter Email",
+      "content": {
+        "header": "Enter your email address",
+        "errors": {
+          "validationError": "Enter your email address"
+        }
+      }
+    },
+    "summaryPage": {
+      "title": "Summary Page",
+      "content": {
+        "header": "Check answers",
+        "changeLink": "Change"
+      }
+    }
+  }
+}

--- a/src/views/chooseLocation.njk
+++ b/src/views/chooseLocation.njk
@@ -1,10 +1,10 @@
 {% extends 'common/base.njk' %}
-{% set title = 'Choose Location' %}
+{% set title = 'pages.chooseLocation.title' %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% block backLink %}
-  {{ govukBackLink({ text: "Back", href: "/service-description" }) }}
+  {{ govukBackLink({ text: "general.govuk.backLink" | translate, href: "/service-description" }) }}
 {% endblock %}
 {% block content %}
 
@@ -14,62 +14,62 @@
   id: "choose-location",
   name: "chooseLocation",
   label: {
-    text: "Choose your location",
+    text:  "pages.chooseLocation.content.header" | translate,
     classes: "govuk-label--l",
     isPageHeading: true
   },
   hint: {
-    text: "This can be different to where you went before"
+    text: "pages.chooseLocation.content.hint" | translate
   },
   errorMessage: {
-    text: "Select a location"
+    text: "pages.chooseLocation.content.errors.validationError" | translate
   }if showError,
   items: [
     {
       value: "",
-      text: "Choose location",
+      text: "pages.chooseLocation.content.options.chooseLocation" | translate,
       selected: true
     },
     {
       value: "East Midlands",
-      text: "East Midlands"
+      text: "pages.chooseLocation.content.options.eastMidlands" | translate
     },
     {
       value:  "East of England",
-      text: "East of England"
+      text: "pages.chooseLocation.content.options.eastEngland" | translate
     },
     {
       value: "London",
-      text: "London"
+      text: "pages.chooseLocation.content.options.london" | translate
     },
     {
       value: "North East",
-      text: "North East"
+      text:  "pages.chooseLocation.content.options.northEast" | translate
     },
     {
       value: "North West",
-      text: "North West"
+      text: "pages.chooseLocation.content.options.northWest" | translate
     },
     {
       value: "South East",
-      text: "South East"
+      text: "pages.chooseLocation.content.options.southEast" | translate
     },
     {
       value: "South West",
-      text: "South West"
+      text: "pages.chooseLocation.content.options.southWest" | translate
     },
     {
       value: "West Midlands",
-      text: "West Midlands"
+      text: "pages.chooseLocation.content.options.westMidlands" | translate
     },
     {
       value: "Yorkshire and the Humber",
-      text: "Yorkshire and the Humber"
+      text: "pages.chooseLocation.content.options.yorkshireAndHumber" | translate
     }
   ]
 }) }}
     {{ govukButton({
-  text: "Continue",
+  text: "general.buttons.continue" | translate,
   type: "submit"
 }) }}
   </form>

--- a/src/views/common/banner.njk
+++ b/src/views/common/banner.njk
@@ -1,16 +1,20 @@
 {% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
 
 {% set html %}
-<p class="govuk-body">We use some essential cookies to make this service work.</p>
-<p class="govuk-body">We'd like to set additional cookies so we can remember your settings, understand how people use the service and make improvements.</p>
+<p class="govuk-body">{{"general.cookie.cookieBanner.paragraph1" | translate}}</p>
+<p class="govuk-body">{{"general.cookie.cookieBanner.paragraph2" | translate}}</p>
 {% endset %}
 
 {% set acceptHtml %}
-<p class="govuk-body">We use some essential cookies to make this service work. <a class="govuk-link" href="https://signin.account.gov.uk/cookies">change your cookie settings</a> at any time.</p>
+<p class="govuk-body">{{"general.cookie.cookieBanner.cookieBannerAccept.paragraph1" | translate}}
+  <a class="govuk-link" href="https://signin.account.gov.uk/cookies">{{"general.cookie.cookieBanner.changeCookiePreferencesLink" | translate}}</a>
+  {{"general.cookie.cookieBanner.cookieBannerAccept.paragraph2" | translate}}</p>
 {% endset %}
 
 {% set rejectedHtml %}
-<p class="govuk-body">You've rejected additional cookies. You can  <a class="govuk-link" href="https://signin.account.gov.uk/cookies">change your cookie settings</a> at any time.</p>
+<p class="govuk-body">{{"general.cookie.cookieBannerReject.paragraph1" | translate}}
+  <a class="govuk-link" href="https://signin.account.gov.uk/cookies">{{"general.cookie.cookieBanner.changeCookiePreferencesLink" | translate}}</a>
+  {{"general.cookie.cookieBannerReject.paragraph2" | translate}}</p>
 {% endset %}
 
 {{ govukCookieBanner({
@@ -19,7 +23,7 @@
    classes: "cookieBannerContainer",
   messages: [
     {
-      headingText: "Cookies on GA4",
+      headingText:"general.cookie.cookieBanner.heading" | translate,
       html: html,
       attributes: {
       "id": "cookies-banner-main",
@@ -27,17 +31,17 @@
     },
       actions: [
         {
-          text: "Accept analytics cookies",
+          text: "general.cookie.buttonAcceptText" | translate,
           type: "button",
           name: "cookiesAccept"
         },
         {
-          text: "Reject analytics cookies",
+          text: "general.cookie.buttonRejectText" | translate,
           type: "button",
           name: "cookiesReject"
         },
         {
-          text: "View cookies",
+          text: "general.cookie.linkViewCookies" | translate,
           href: "https://signin.account.gov.uk/cookies"
         }
       ]
@@ -50,7 +54,7 @@
       },
       actions: [
         {
-          text: "Hide cookie message",
+          text:  "general.cookie.cookieBannerHideLinkText" | translate,
           href: "#",
           type: "button",
           classes:"cookie-hide-button",
@@ -69,7 +73,7 @@
       },
       actions: [
         {
-          text: "Hide cookie message",
+          text: "general.cookie.cookieBannerHideLinkText" | translate,
           href: "#",
           type: "button",
           classes:"cookie-hide-button",

--- a/src/views/common/base.njk
+++ b/src/views/common/base.njk
@@ -12,7 +12,7 @@
 {% block skipLink %}
   {{ govukSkipLink({ 
   href: "#main-content", 
-  text: 'Skip to main content' }) }}
+  text: "general.govuk.skipLink" | translate }) }}
 {% endblock %}
 
 {% block bodyStart %}
@@ -30,9 +30,9 @@
   <div class="govuk-width-container">
     {{ govukPhaseBanner({
   tag: {
-    text: "Alpha"
+    text: "general.govuk.phaseBanner.tag" | translate
   },
-  html: 'This is a new service - your <a class="govuk-link" href="https://signin.dev.account.gov.uk/contact-us" target="blank">feedback</a> will help us to improve it. For more information, please <a href="/">restart</a> your journey'
+  html:"general.govuk.phaseBanner.content" | translate | safe
 }) }}
     {% block backLink%}{% endblock %}
     <main id="main-content" class="govuk-main-wrapper">
@@ -59,7 +59,7 @@
         taxonomy_level2: '{{ taxonomyLevel2 }}', // Access taxonomy level 2
         content_id: '{{contentId}}',
         logged_in_status: false,
-        dynamic: false,
+        dynamic: false
       });
   </script>
 {% endblock %}
@@ -69,11 +69,11 @@
       meta: { 
         items: [ { 
           href: "#",
-          text: "Help" }, { 
+          text: "general.footer.help.linkText" | translate }, { 
             href: "#", 
-            text: "Cookies" }, { 
+            text: "general.footer.cookies.linkText" | translate }, { 
               href: "#", 
-              text: "Contact" },
+              text: "general.footer.contact.linkText" | translate},
   { href: "#", 
-  text: "Terms and conditions" } ] } }) }}
+  text: "general.footer.terms.linkText" | translate } ] } }) }}
 {% endblock %}

--- a/src/views/enterEmail.njk
+++ b/src/views/enterEmail.njk
@@ -1,28 +1,28 @@
 {% extends 'common/base.njk' %}
-{% set title = 'Enter Email' %}
+{% set title = 'pages.enterEmail.title' %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% block backLink %}
-  {{ govukBackLink({ text: "Back", href: "/choose-location" }) }}
+  {{ govukBackLink({ text: "general.govuk.backLink" | translate, href: "/choose-location" }) }}
 {% endblock %}
 {%block content%}
 
   <form method="post" id="enterEmailForm">
     {{ govukInput({
   label: {
-    text: "Enter your email address",
+    text: "pages.enterEmail.content.header" | translate,
     classes: "govuk-label--l",
     isPageHeading: true
   },
   id: "enter-email",
   name: "enterEmail",
   errorMessage: {
-    text: "Enter your email address"
+    text: "pages.enterEmail.content.errors.validationError" | translate
   } if showError
 }) }}
     {{ govukButton({
-  text: "Continue",
+  text: "general.buttons.continue" | translate,
   type: "submit"
 }) }}
   </form>

--- a/src/views/helpWithHint.njk
+++ b/src/views/helpWithHint.njk
@@ -1,11 +1,11 @@
 {% extends 'common/base.njk' %}
-{% set title = 'Help With Hint' %}
+{% set title = 'pages.helpWithHint.title' %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% block backLink %}
-  {{ govukBackLink({ text: "Back", href: "/organisation-type" }) }}
+  {{ govukBackLink({ text: "general.govuk.backLink" | translate, href: "/organisation-type" }) }}
 {% endblock %}
 {% block content %}
 
@@ -15,43 +15,43 @@
   name: "helpWithHint",
   fieldset: {
     legend: {
-      text: "What would you like help with?",
+      text: "pages.helpWithHint.content.header" | translate,
       isPageHeading: true,
       classes: "govuk-fieldset__legend--l"
     }
   },
   hint: {
-    text: "Tick all that apply - this will help us understand your initial needs"
+    text: "pages.helpWithHint.content.hint" | translate
   },
    errorMessage: {
-    text: "Select one or more options"
+    text: "pages.helpWithHint.content.errors.validationError" | translate
   } if showError, 
   items: [
     {
       value: "Getting access to the integration environment to test GOV.UK One Login",
-      text: "Getting access to the integration environment to test GOV.UK One Login"
+      text: "pages.helpWithHint.content.options.accessIntegrationEnvironment" | translate
     },
     {
       value: "Having a technical discussion",
-      text: "Having a technical discussion"
+      text: "pages.helpWithHint.content.options.technicalDiscussion" | translate
     },
     {
       value: "Walking through the onboarding process",
-      text: "Walking through the onboarding process"
+      text: "pages.helpWithHint.content.options.onboardingProcess" | translate
     },
     {
       value: "Understanding the GOV.UK One Login programme in more detail",
-      text: "Understanding the GOV.UK One Login programme in more detail"
+      text: "pages.helpWithHint.content.options.moreDetail" | translate
     },
      {
       value: "Other",
-      text: "Other"
+      text: "pages.helpWithHint.content.options.other" | translate
     }
   ]
 }) }}
 
     {{ govukButton({
-  text: "Continue",
+  text: "general.buttons.continue" | translate,
   type: "submit"
 }) }}
   </form>

--- a/src/views/home.njk
+++ b/src/views/home.njk
@@ -1,60 +1,56 @@
 {% extends 'common/base.njk' %}
-{% set title = 'Home' %}
+{% set title = 'pages.home.title' %}
 {% block content %}
 
-    <h1 class="govuk-heading-xl">Using your GOV.UK One Login</h1>
+    <h1 class="govuk-heading-xl">{{"pages.home.content.header"| translate}}</h1>
     <aside>
         <nav>
-            <h2 class="govuk-heading-m">Contents</h2>
+            <h2 class="govuk-heading-m">{{"pages.home.content.navHeading"| translate}}</h2>
             <ol class="govuk-list govuk-list--number">
-                <li>Sign in to your GOV.UK One Login</li>
+                <li>{{"pages.home.content.list1"| translate}}</li>
                 <li>
-                    <a href="/service-description" class="govuk-link">Test Inbound Link</a>
+                    <a href="/service-description" class="govuk-link">{{"pages.home.content.list2"| translate}}</a>
                 </li>
                 <li>
-                    <a href="https://apps.apple.com/gb/app/gov-uk-id-check/id1629050566" class="govuk-link">Test Outbound link</a>
+                    <a href="https://apps.apple.com/gb/app/gov-uk-id-check/id1629050566" class="govuk-link">{{"pages.home.content.list3"| translate}}</a>
                 </li>
             </ol>
         </nav>
     </aside>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
-    <h1 class="govuk-heading-l">Sign in to your GOV.UK One Login</h1>
-    <p class="govuk-body">You can use your GOV.UK One Login to access some government services.</p>
+    <h1 class="govuk-heading-l">{{"pages.home.content.subheading1"| translate}}</h1>
+    <p class="govuk-body">{{"pages.home.content.paragraph1"| translate}}</p>
     <p class="govuk-body">
- It does not work with all <a href="#" class="govuk-link"> government accounts and services</a> yet (for example
- Government Gateway or Universal Credit).
-</p>
-    <p class="govuk-body">In the future, you’ll be able to use your GOV.UK One Login to access all services on GOV.UK.</p>
-    <p class="govuk-body">See the <a href="#" class="govuk-link"> services you can use with GOV.UK One Login.</a>
+        {{"pages.home.content.paragraph2"| translate| safe}}
+    </p>
+    <p class="govuk-body">{{"pages.home.content.paragraph3"| translate}}</p>
+    <p class="govuk-body">{{"pages.home.content.paragraph4"| translate| safe}}
     </p>
     {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
-    {{ govukInsetText({ text: "If you need a GOV.UK
-One Login to use a service, and you do not already have one, you’ll be able to create one when you first use that
-service." }) }}
+    {{ govukInsetText({ text: "pages.home.content.insetText"| translate }) }}
 
-    <p class="govuk-body">Sign in to:</p>
+    <p class="govuk-body">{{"pages.home.content.paragraph5"| translate}}</p>
     <ul class="govuk-list govuk-list--bullet">
-        <li>change your sign in details (email address, password or how you get security codes)</li>
-        <li>see and access the services you’ve used with your GOV.UK One Login</li>
-        <li>delete your GOV.UK One Login</li>
+        <li>{{"pages.home.content.list4"| translate}}</li>
+        <li>{{"pages.home.content.list5"| translate}}</li>
+        <li>{{"pages.home.content.list6"| translate}}</li>
     </ul>
     {% from "govuk/components/button/macro.njk" import govukButton %}
-    {{ govukButton({ text: "Start Now", href:
+    {{ govukButton({ text: "general.buttons.startNow"|translate, href:
 "/organisation-type", isStartButton: true }) }}
 
-    <h2 class="govuk-heading-m">Report a problem or give feedback</h2>
+    <h2 class="govuk-heading-m">{{"pages.home.content.subheading2"| translate}}</h2>
     <p class="govuk-body">
- To report a problem with your GOV.UK One Login or give feedback,
- <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link">contact the GOV.UK One Login team</a
- >.
-</p>
+        {{"pages.home.content.paragraph6"| translate| safe}}
+    </p>
     {% from "govuk/components/pagination/macro.njk" import govukPagination %}
     {{ govukPagination({ next: { labelText:
-"Services you can use with GOV.UK One Login", href: "#" } }) }}
+"pages.home.content.pagination.text"| translate, href: "#" } }) }}
 
     <div>
-        <a href="#" class="govuk-link govuk-link--no-visited-state govuk-body"> View a printable version of the whole guide</a>
+        <a href="#" class="govuk-link govuk-link--no-visited-state govuk-body">
+            {{"pages.home.content.printGuideLinkText"| translate}}</a>
     </div>
     <script>
         localStorage.clear();

--- a/src/views/journeyGuard.njk
+++ b/src/views/journeyGuard.njk
@@ -1,8 +1,9 @@
 {% extends 'common/base.njk' %}
-{% set title = 'Journey Guard' %}
+{% set title = 'pages.journeyGuard.title' %}
 {%block content%}
-    <h1 class="govuk-heading-l">Sorry, you can not access OneLogin GOV.UK from this page </h1>
+    <h1 class="govuk-heading-l">{{"pages.journeyGuard.content.header" | translate}}
+    </h1>
     <p class="govuk-body">
-        <a href="/welcome" class="govuk-link"> Go to the GOV.UK OneLogin homepage</a> to find the service you need.
-</p>
+        {{"pages.journeyGuard.content.paragraph1" | translate|safe}}
+    </p>
     {%endblock%}

--- a/src/views/organisationType.njk
+++ b/src/views/organisationType.njk
@@ -1,14 +1,12 @@
 {% extends 'common/base.njk' %}
-{% set title = 'Organisation Type' %}
+{% set title = 'pages.organisationType.title' %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% set title = 'Organisation Type' %}
-
 {% block backLink %}
   {{ govukBackLink({
-  text: "Back",
+  text: "general.govuk.backLink" | translate,
   href: "/welcome"
 }) }}
 {% endblock %}
@@ -19,7 +17,7 @@
   id: "organisation-type",
   fieldset: {
     legend: {
-      text: "What is your organisation type?",
+      text: "pages.organisationType.content.header" | translate,
       isPageHeading: true,
       classes: "govuk-fieldset__legend--l"
       
@@ -28,26 +26,26 @@
   items: [
     {
       value: "Government department or Ministry",
-      text: "Government department or Ministry"
+      text: "pages.organisationType.content.options.governmentDepartmentOrMinistry" | translate
     },
     {
       value: "Executive Agency",
-      text: "Executive Agency"
+      text: "pages.organisationType.content.options.executiveAgency" | translate
     },
     {
       value: "Arms length body",
-      text: "Arms length body"
+      text: "pages.organisationType.content.options.armsLengthBody" | translate
     },
     {
       value: "Other",
-      text: "Other"
+      text: "pages.organisationType.content.options.other" | translate
     }
   ],
-   errorMessage:  { text: "Select one option" }  if showError
+   errorMessage:  { text: "pages.organisationType.content.errors.validationError" | translate}  if showError
 }) }}
 
     {{ govukButton({
-    text: "Continue",
+    text: "general.buttons.continue" | translate,
     type: 'submit'
   }) }}
 

--- a/src/views/serviceDescription.njk
+++ b/src/views/serviceDescription.njk
@@ -1,10 +1,10 @@
 {% extends 'common/base.njk' %}
-{% set title = 'Service Description' %}
+{% set title = 'pages.serviceDescription.title' %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% block backLink %}
-  {{ govukBackLink({ text: "Back", href: "/help-with-hint" }) }}
+  {{ govukBackLink({ text: "general.govuk.backLink" | translate, href: "/help-with-hint" }) }}
 {% endblock %}
 {% block content %}
 
@@ -14,19 +14,19 @@
   name: "serviceDescription",
   id: "service-description",
   label: {
-    text: "Describe your service",
+    text: "pages.serviceDescription.content.header" | translate,
     classes: "govuk-label--l",
     isPageHeading: true
   },
   hint: {
-    text: "Describe your service, what it does, who it helps and why? Also tell us if it's a new service that has not launched yet."
+    text:  "pages.serviceDescription.content.hint" | translate
   },
   errorMessage: {
-    text: "Enter a short description of your service"
+    text: "pages.serviceDescription.content.errors.validationError" | translate
   } if showError
 }) }}
     {{ govukButton({
-  text: "Continue",
+  text: "general.buttons.continue" | translate,
   type: "submit"
 }) }}
   </form>

--- a/src/views/summaryPage.njk
+++ b/src/views/summaryPage.njk
@@ -1,5 +1,5 @@
 {% extends 'common/base.njk' %}
-{% set title = 'Summary page' %}
+{% set title = 'pages.summaryPage.title' %}
 
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
@@ -25,7 +25,7 @@
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% block backLink %}
-  {{ govukBackLink({ text: "Back", href: "/enter-email" }) }}
+  {{ govukBackLink({ text: "general.govuk.backLink" | translate, href: "/enter-email" }) }}
 {% endblock %}
 
 {% block content %}
@@ -36,7 +36,7 @@
     classes: "govuk-summary-list__row--no-actions",
       fieldset: {
     legend: {
-      text: "Check answers",
+      text: "pages.summaryPage.content.header" | translate,
       isPageHeading: true,
       classes: "govuk-fieldset__legend--l"
     }
@@ -44,7 +44,7 @@
   rows: [
     {
       key: {
-        text: "What is your organisation type?"
+        text: "pages.organisationType.content.header" | translate
       },
     value: {
         html:  organisationTypeHtml 
@@ -53,7 +53,7 @@
         items: [
           {
             href: "/organisation-type?editMode=true",
-            text: "Change",
+            text: "pages.summaryPage.content.changeLink" | translate,
             visuallyHiddenText: "organisationType"
           }
         ]
@@ -61,7 +61,7 @@
     },
     {
       key: {
-        text: "What would you like help with?"
+        text: "pages.helpWithHint.content.header" | translate
       },
       value: {
         html: helpWithHintsHtml
@@ -70,15 +70,15 @@
         items: [
           {
             href: "/help-with-hint?editMode=true",
-            text: "Change",
-            visuallyHiddenText: "helpWithHints"
+            text: "pages.summaryPage.content.changeLink" | translate,
+            visuallyHiddenText: "helpWithHint"
           }
         ]
       }
     },
     {
       key: {
-        text: "Describe your service"
+        text: "pages.serviceDescription.content.header" | translate
       },
       value: {
         html: serviceDescriptionHtml
@@ -87,7 +87,7 @@
         items: [
           {
             href: "/service-description?editMode=true",
-            text: "Change",
+            text: "pages.summaryPage.content.changeLink" | translate,
             visuallyHiddenText: "Service description"
           }
         ]
@@ -95,7 +95,7 @@
     },
     {
       key: {
-        text: "Choose your location"
+        text: "pages.chooseLocation.content.header" | translate
       },
       value: {
         html:  chooseLocationHtml
@@ -104,7 +104,7 @@
         items: [
           {
             href: "/choose-location?editMode=true",
-            text: "Change",
+            text: "pages.summaryPage.content.changeLink" | translate,
             visuallyHiddenText: "Choose location"
           }
         ]
@@ -112,7 +112,7 @@
     },
      {
       key: {
-        text: "What is your email"
+        text: "pages.enterEmail.content.header" | translate
       },
       value: {
         html:  enterEmailHtml
@@ -121,7 +121,7 @@
         items: [
           {
             href: "/enter-email?editMode=true",
-            text: "Change",
+            text: "pages.summaryPage.content.changeLink" | translate,
             visuallyHiddenText: "Enter email"
           }
         ]


### PR DESCRIPTION
### Description

- Text moved into JSON content files and replaced with variables
- Adds `locales` folder with en and cy subfolders, each containing a translation.json file.
- Adds i18next configuration file
- Add translation package (i18n)

### Tickets

(DFC-51)[https://govukverify.atlassian.net/browse/DFC-51]

### Steps to Reproduce

Run the App

- Navigate to /welcome 
- Clear Cookies
- Add the language parameter to the URL. For example, if you are on the home page (/welcome), change the URL from /welcome to `/welcome?lng=cy `for Welsh.
- Verify in GTM to ensure that the trackers are detecting the translated content.

### Co-Authored By

### Additional Information
