### PR TITLE
[DFC-381]: Add accessibility and design amend requests

### DIFF
--- a/src/components/language-toggle/README.md
+++ b/src/components/language-toggle/README.md
@@ -86,11 +86,13 @@ The package is owned by the DI Frontend Capability team, part of the development
          languages: [
            {
              code: "en",
-             text: "English"
+             text: "English",
+              visuallyHidden: "Change to English"
            },
            {
              code: "cy",
-             text: "Cymraeg"
+             text: "Cymraeg",
+             visuallyHidden: "Newid yr iaith ir Gymraeg"
            }
          ]
        });
@@ -117,6 +119,7 @@ The package is owned by the DI Frontend Capability team, part of the development
 - `activeLanguage` contains the language code of your i18next active language e.g 'en'
 - `class` lets you add any css class to the nunjuck component.
 - `languages` is an array of all the languages you support in your application.
+- Language toggle to be placed above the back button.
   [!NOTE]
 
 ### Prerequisites

--- a/src/components/language-toggle/language-select.yaml
+++ b/src/components/language-toggle/language-select.yaml
@@ -29,5 +29,9 @@ params:
         type: string
         required: true
         description: language text
+      - name: visuallyHidden
+        type: string
+        required: false
+        description: language text
 
 

--- a/src/components/language-toggle/stylesheet/styles.css
+++ b/src/components/language-toggle/stylesheet/styles.css
@@ -1,12 +1,11 @@
 /* styles.css */
 
 .language-select {
-  padding-bottom: 10px;
+  margin: 16px 0 16px 0;
 }
 
 .language-select__list {
   margin-top: 1em;
-  float: right;
   text-align: right;
 }
 
@@ -26,4 +25,13 @@
 .language-select__list-item a,
 .language-select__list-item [aria-current] {
   padding: 0.3125em;
+}
+
+@media screen and (max-width: 641px) {
+  .language-select__list {
+    float: none;
+    text-align: left;
+    padding-bottom: 10px;
+    border-bottom: 1px solid #b1b4b6;
+  }
 }

--- a/src/components/language-toggle/template.njk
+++ b/src/components/language-toggle/template.njk
@@ -1,13 +1,18 @@
-<nav class="language-select {{params.class}}" aria-label="{{params.ariaLabel}}">
-    <ul class="govuk-list language-select__list govuk-body-s">
+<nav class="language-select {{params.class}}" aria-label="{{params.ariaLabel}}" role="navigation">
+    <ul class="govuk-list language-select__list govuk-body-s govuk-!-margin-0" role="list">
         {% for lang in params.languages %}
-            <li class="language-select__list-item">
+            <li class="language-select__list-item" role="listitem">
                 {% if params.activeLanguage == lang.code %}
                     <span aria-current="language">{{ lang.text }}</span>
                 {% else %}
-                    <a class="govuk-link govuk-link--no-visited-state language-select__link" href="?lng={{ lang.code }}">
-                        {{ lang.text }}
-                    </a>
+                    <a 
+                    class="govuk-link govuk-link--no-visited-state" 
+                    href="?lng={{ lang.code }}" 
+                    data-journey-click="link - click:lang-select:{{ lang.code }}"
+                    rel="alternate" 
+                    hreflang="{{ lang.code }}"
+                    role="link"
+                    >{{ lang.text }}<span class="govuk-visually-hidden">{{ lang.visuallyHidden }}</span></a>
                 {% endif %}
             </li>
         {% endfor %}

--- a/src/components/language-toggle/template.njk
+++ b/src/components/language-toggle/template.njk
@@ -12,7 +12,7 @@
                     rel="alternate" 
                     hreflang="{{ lang.code }}"
                     role="link"
-                    >{{ lang.text }}<span class="govuk-visually-hidden">{{ lang.visuallyHidden }}</span></a>
+                    >{{ lang.text }}<div class="govuk-visually-hidden">{{ lang.visuallyHidden }}</div></a>
                 {% endif %}
             </li>
         {% endfor %}

--- a/src/components/language-toggle/template.test.js
+++ b/src/components/language-toggle/template.test.js
@@ -18,11 +18,13 @@ describe("oneloginLanguageSelect Component", () => {
     languages: [
       {
         code: "en",
-        text: "English"
+        text: "English",
+        visuallyHidden: "Change to English"
       },
       {
         code: "cy",
-        text: "Cymraeg"
+        text: "Cymraeg",
+        visuallyHidden: "Newid yr iaith ir Gymraeg"
       }
     ]
   };
@@ -67,11 +69,14 @@ describe("oneloginLanguageSelect Component", () => {
         languages: [
           {
             code: "en",
-            text: "English"
+            text: "English",
+            visuallyHidden: "Change to English"
+
           },
           {
             code: "cy",
-            text: "Cymraeg"
+            text: "Cymraeg",
+            visuallyHidden: "Newid yr iaith ir Gymraeg"
           }
         ]
       };
@@ -83,8 +88,12 @@ describe("oneloginLanguageSelect Component", () => {
       );
 
       // test span
-      const renderedSpan = renderedComponent("span").text();
-      expect(renderedSpan).toBe("Cymraeg");
+      const renderedSpan = renderedComponent("span")
+      expect(renderedSpan.text()).toBe("Cymraeg");
+
+      // test visually hidden
+      const renderedVisuallyHidden = renderedComponent(".govuk-visually-hidden");
+      expect(renderedVisuallyHidden.text()).toBe("Change to English");
 
       // test link
       const renderedLink = renderedComponent(".govuk-link");
@@ -106,6 +115,10 @@ describe("oneloginLanguageSelect Component", () => {
       // test span
       const renderedSpan = renderedComponent("span").text();
       expect(renderedSpan).toBe("English");
+
+      // test visually hidden
+      const renderedVisuallyHidden = renderedComponent(".govuk-visually-hidden");
+      expect(renderedVisuallyHidden.text()).toBe("Newid yr iaith ir Gymraeg");
 
       // test link
       const renderedLink = renderedComponent(".govuk-link");

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -6,7 +6,7 @@
       "menuLink3": "dewislen 3"
     },
     "languageSelect":{
-      "ariaLabel":"Lorem ipsum"
+      "ariaLabel":"Switcher iaith"
     },
     "buttons": {
       "startNow": "Dechrau Nawr",

--- a/src/views/common/base.njk
+++ b/src/views/common/base.njk
@@ -52,18 +52,23 @@
         activeLanguage: htmlLang,
         class:'',
         languages: [
-        { 
-          code: 'en',
-          text: 'English'
-        },
-        {
-          code:'cy',
-          text: 'Cymraeg'
-        }]
+          { 
+            code: 'en',
+            text: 'English',
+            visuallyHidden: 'Change to English'
+          },
+          {
+            code:'cy',
+            text: 'Cymraeg',
+            visuallyHidden: 'Newid yr iaith ir Gymraeg'
+          }
+        ]
       })
-    }}
-    {% block backLink%}{% endblock %}
-    <main id="main-content" class="govuk-main-wrapper">
+      }}
+
+    {% block backLink %}{% endblock %}
+
+    <main id="main-content" class="govuk-main-wrapper govuk-!-padding-top-3">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           {% block content %}{% endblock %}


### PR DESCRIPTION
## Description
(DFC-381)[https://govukverify.atlassian.net/browse/DFC-381]

All requirements are detailed on the ticket - these were the points to change as a result of the call with Derren Wilson (Accessibility) and Matt Ashton (UCD).

## Accessibility
- Links to have aria-hidden attribute “change to x” must be in passed into the component in alternate language, so assistive technology reads out “Change to x”
- Aria-roles to be added to the navigation, list and links
- Add hreflang="x" rel="alternate" to links
- Aria-label to be a translated param so that “Choose a language” is localised

## Analytics
- Add link - click:lang-select:{{ lang.code }} to the links

## Design
- Add border bottom to the smaller devices (tablet + mobile)
- Language toggle to be positioned above the back button
- Apply text positioning on a smaller devices - float left

### Steps to Reproduce

If running locally, you need to amend where the component is looking up (from npm registry to the local component)
1. Amend the component import in base.njk to
`{% from "language-toggle/macro.njk" import oneloginLanguageSelect %}`
2. Amend the build-sass command to the below
`"build-sass": "rm -rf public/style.css && sass --no-source-map src/components/language-toggle/stylesheet/styles.css  public/stylesheets/application.css --style compressed"`
2. Run `npm run start`

This will now pick up and build the localised component with all the changes

### Test coverage
![Screenshot 2024-02-23 at 14 25 40](https://github.com/govuk-one-login/di-fec-ga4-demo/assets/38694448/3eaabc78-ab12-49f6-918d-9a82e15b3b92)

### Screenshots
<img width="837" alt="Screenshot 2024-02-22 at 17 43 56" src="https://github.com/govuk-one-login/di-fec-ga4-demo/assets/38694448/e512cf84-c90f-4d73-bf7e-f22c44ca0bfa">
<img width="811" alt="Screenshot 2024-02-22 at 17 43 41" src="https://github.com/govuk-one-login/di-fec-ga4-demo/assets/38694448/d6cb771a-df40-4bef-b62a-b7170674cd36">
<img width="503" alt="Screenshot 2024-02-22 at 17 39 23" src="https://github.com/govuk-one-login/di-fec-ga4-demo/assets/38694448/b520bb06-ab67-42a6-9d42-15a6a0c4009e">




