### PR TITLE
Language Toggle/Bug Fix: Modify param setter to accept a URL instead of a string

### DIFF
--- a/src/components/frontend-language-toggle/language-param-setter.test.ts
+++ b/src/components/frontend-language-toggle/language-param-setter.test.ts
@@ -3,21 +3,21 @@ import addLanguageParam from "./language-param-setter";
 describe("addLanguageParam function", () => {
   it("should add language parameter to URL", () => {
     const language = "en";
-    const url = "http://example.com";
+    const url = new URL("http://example.com");
 
     const result = addLanguageParam(language, url);
     expect(result).toContain("lng=en");
   });
 
   it("should add language parameter to URL without any existing parameters", () => {
-    const result = addLanguageParam("en", "http://example.com");
+    const result = addLanguageParam("en", new URL("http://example.com"));
     expect(result).toContain("/?lng=en");
   });
 
   it("should add language parameter to URL with existing parameters", () => {
     const result = addLanguageParam(
       "en",
-      "http://localhost:6001/path?param1=value1"
+      new URL("http://localhost:6001/path?param1=value1")
     );
     expect(result).toContain("/path?");
     expect(result).toContain("lng=en");
@@ -26,7 +26,7 @@ describe("addLanguageParam function", () => {
   it("should not duplicate the language parameter in URL", () => {
     const result = addLanguageParam(
       "cy",
-      "http://localhost:6001/path?param1=value1&lng=en"
+      new URL("http://localhost:6001/path?param1=value1&lng=en")
     );
     expect(result).toContain("/path?");
     expect(result).toContain("param1=value1");

--- a/src/components/frontend-language-toggle/language-param-setter.ts
+++ b/src/components/frontend-language-toggle/language-param-setter.ts
@@ -1,5 +1,4 @@
-export default function addLanguageParam(language: string, url: string) {
-  const parsedUrl = new URL(url);
-  parsedUrl.searchParams.set("lng", language);
-  return parsedUrl.pathname + parsedUrl.search;
+export default function addLanguageParam(language: string, url: URL) {
+  url.searchParams.set("lng", language);
+  return url.pathname + url.search;
 };


### PR DESCRIPTION
Part of the review of the Language Toggle CE pointed out that constructing the URL via string concatenation and assigning to a variable rather than constructing the URL via `new URL()` to begin which could cause issues if this variable is reused elsewhere. Removing the URL parsing from the LT allow it to be performed when the variable is declared in target repo middleware
